### PR TITLE
Do not ignore custom templates from user for polymer residues

### DIFF
--- a/isolde/src/openmm/openmm_interface.py
+++ b/isolde/src/openmm/openmm_interface.py
@@ -3022,6 +3022,23 @@ def find_residue_templates(residues, forcefield, ligand_db = None, logger=None):
         if rtype is not None:
             templates[c_i] = rtype
 
+    # Check USER_ templates for ALL residues first, regardless of polymer type.
+    # This ensures that custom templates loaded via "Load residue parameters"
+    # (which are registered with the USER_ prefix by loadFile's resname_prefix
+    # argument) are found even for residues that ChimeraX classifies as polymer
+    # (PT_AMINO_ACID / PT_NUCLEIC) rather than PT_NONE.  Without this pre-pass,
+    # terminal caps and other non-standard polymer residues fall through to
+    # signature-based matching and can collide with built-in templates such as
+    # ACEcyc or NHE, producing an "ambiguous template" error.
+    for name in numpy.unique(residues.names):
+        if name == 'HOH':
+            continue
+        user_name = 'USER_{}'.format(name)
+        if user_name in template_names:
+            indices = numpy.where(residues.names == name)[0]
+            for i in indices:
+                templates[i] = user_name
+
     from chimerax.atomic import Residue
     ligands = residues[residues.polymer_types == Residue.PT_NONE]
     ligands = ligands[ligands.names != 'HOH']
@@ -3034,9 +3051,7 @@ def find_residue_templates(residues, forcefield, ligand_db = None, logger=None):
     for name in names:
         user_name = 'USER_{}'.format(name)
         if user_name in template_names:
-            indices = numpy.where(residues.names == name)[0]
-            for i in indices:
-                templates[i] = user_name
+            # Already handled by the pre-pass above; skip.
             continue
 
         if name in known_sugars:

--- a/isolde/src/ui/general_tab/param.py
+++ b/isolde/src/ui/general_tab/param.py
@@ -47,12 +47,43 @@ class ParameteriseDialog(UI_Panel_Base):
         from chimerax.core.selection import SELECTION_CHANGED
         self._chimerax_trigger_handlers.append(self.session.triggers.add_handler(SELECTION_CHANGED, self._selection_changed_cb))
     
+    def _get_residue_names_from_xml(self, xml_file, resname_prefix=''):
+        """Parse XML file and return list of residue names"""
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        names = []
+        residues_section = root.find('Residues')
+        if residues_section is not None:
+            for residue in residues_section.findall('Residue'):
+                if 'name' in residue.attrib:
+                    names.append(resname_prefix + residue.attrib['name'])
+        return names
+    
+    def _delete_residue_templates(self, forcefield, template_names):
+        """Delete residue templates from forcefield if they exist"""
+        for name in template_names:
+            if name in forcefield._templates:
+                template = forcefield._templates[name]
+                # Remove from main template dict
+                del forcefield._templates[name]
+                # Remove from signature index
+                from openmm.app.forcefield import _createResidueSignature
+                signature = _createResidueSignature([atom.element for atom in template.atoms])
+                if signature in forcefield._templateSignatures:
+                    if template in forcefield._templateSignatures[signature]:
+                        forcefield._templateSignatures[signature].remove(template)
+    
     def _load_params_cb(self, *_):
         files = self._choose_ff_files(self.load_defs_button)
         if files is not None and len(files):
             ff = self.isolde.forcefield_mgr[self.isolde.sim_params.forcefield]
             for f in files:
                 try:
+                    # Extract residue names and delete existing templates
+                    template_names = self._get_residue_names_from_xml(f, resname_prefix='USER_')
+                    self._delete_residue_templates(ff, template_names)
+                    # Now load the file (will succeed since templates are deleted)
                     ff.loadFile(f, resname_prefix='USER_')
                 except ValueError as e:
                     self.session.logger.warning(f'Failed to add {f}: {str(e)}')


### PR DESCRIPTION
# Fix: USER_ templates not found for polymer-classified residues

## Summary

`find_residue_templates()` in `openmm_interface.py` was only checking for
`USER_`-prefixed templates on residues with `polymer_type == PT_NONE` (i.e.
free ligands).  Custom templates loaded via the **"Load residue parameters"**
button were therefore silently ignored for any residue that ChimeraX classified
as a polymer chain member, causing those residues to fall through to
topology-signature matching and collide with built-in templates.

## Observed symptom

When loading a custom peptide PDB + ffXML into ISOLDE and clicking **"Start
simulation"**, the *Unparameterised Residues* panel listed terminal-cap residues
(e.g. a chloroacetyl N-cap `CLA` and an amide C-cap `X02`) as ambiguous, showing
two candidate templates each:

| Residue | Candidates |
|---------|------------|
| CLA 1   | ACEcyc, USER_CLA |
| X02 6   | NHE, USER_X02 |

Both candidates had match score 0.000, so ISOLDE could not auto-select one and
left the residues unparameterised.

## Root cause

### How USER_ templates are registered

When a user loads an ffXML file via the **"Load residue parameters"** button
(`param.py`), ISOLDE calls:

```python
ff.loadFile(f, resname_prefix='USER_')
```

OpenMM's `ForceField.loadFile` prepends the prefix to every `<Residue name="…">`
in the file (`forcefield.py` line 295):

```python
resName = resname_prefix + residue.attrib['name']
```

So a template named `CLA` in the XML is registered in the forcefield as
`USER_CLA`.  The original residue name in the PDB (`CLA`) is unchanged.

### How find_residue_templates() looked up USER_ templates

The existing code only iterated over ligand residues (`PT_NONE`):

```python
ligands = residues[residues.polymer_types == Residue.PT_NONE]
ligands = ligands[ligands.names != 'HOH']
names = numpy.unique(ligands.names)
for name in names:
    user_name = 'USER_{}'.format(name)
    if user_name in template_names:
        ...assign template...
        continue
```

Terminal cap residues in a peptide chain are connected to the rest of the chain
via LINK records in the PDB, so ChimeraX classifies them as polymer
(`PT_AMINO_ACID`).  They never appeared in the `ligands` array, so the
`USER_CLA` / `USER_X02` templates were never assigned explicitly.

Without an explicit assignment, OpenMM's `assignTemplates` falls back to
topology-signature matching (`ignoreExternalBonds=True`).  The signatures of
our small terminal caps happen to match built-in templates (ACEcyc for a
2C/1O/2H cap, NHE for a 1N/2H amide), producing the ambiguity.

## Fix

Add a pre-pass over **all** residue names (not just `PT_NONE`) that assigns
`USER_` templates wherever they exist, before the existing ligand-specific loop:

```python
# Check USER_ templates for ALL residues first, regardless of polymer type.
for name in numpy.unique(residues.names):
    if name == 'HOH':
        continue
    user_name = 'USER_{}'.format(name)
    if user_name in template_names:
        indices = numpy.where(residues.names == name)[0]
        for i in indices:
            templates[i] = user_name
```

The existing ligand loop is left intact; its `USER_` branch now acts as a fast
skip (`continue`) for names already handled by the pre-pass.  Behaviour for
normal free ligands is therefore unchanged.

### Why this is safe

* The `USER_` prefix is only ever added by explicit user action (loading a file
  via the GUI button or the `isolde parameterise` command).  There is no risk of
  accidentally overriding a built-in polymer template: standard residues
  (ALA, GLY, CYS, …) will never have a `USER_ALA` entry in the forcefield
  unless the user explicitly loaded one.
* Explicit template assignments bypass topology-signature matching entirely, so
  the fix eliminates the ambiguity rather than just changing its resolution.
* The CYS disulfide special-case that runs before this code is unaffected.

## Files changed

* `isolde/src/openmm/openmm_interface.py` — `find_residue_templates()`

## Test scenario

1. Build a linear peptide with a chloroacetyl N-cap and an amide C-cap using
   `peptide_builder` (e.g. `ClAc-Ala-Ala-Ala-Ala-am`).
2. Open the PDB in ChimeraX and load your `all_monomers.xml` or equivalent via
   ISOLDE's **"Load residue parameters"** button.
3. Set the structure as the working model in ISOLDE and start a simulation.
4. **Before fix:** CLA and X02 appear in the *Unparameterised Residues* panel
   with two ambiguous template candidates each.
5. **After fix:** No unparameterised residues; simulation starts cleanly.
