### PR TITLE
New commands enable agentic setup of simulation

### DIFF
--- a/isolde/docs/source/commands/isolde.rst
+++ b/isolde/docs/source/commands/isolde.rst
@@ -91,6 +91,71 @@ Set the specified model as ISOLDE's current selected model. If the target model
 has not already been initialised for control by Clipper to provide ISOLDE's 
 standard view, this command will cause that to happen.
 
+.. _status:
+
+isolde status
+=============
+
+Syntax: isolde status
+
+Report ISOLDE's current state without modifying anything. Logs a one-line
+summary identifying the currently selected model (if any) along with the
+active forcefield and whether a simulation is running, and returns a
+dictionary with the same information for programmatic use. Safe to call at
+any time, including before ``isolde start``. Useful for confirming that an
+``isolde select`` command actually took effect before running preflight
+checks or starting a simulation.
+
+.. _preflight:
+
+isolde preflight
+================
+
+Read-only checks that ask "is this model ready for an ISOLDE simulation?"
+without starting one. These are MD-readiness preflight checks, conceptually
+distinct from ISOLDE's classical model validation (Ramachandran, rotamer,
+geometry, fit-to-data) under the ISOLDE GUI's **Validate** tab. They never
+construct an OpenMM ``Context``, never raise on missing parameters, and
+never modify the model — safe to call at any time once a model is selected.
+
+isolde preflight hydrogens
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Syntax: isolde preflight hydrogens [*model*]
+
+Check whether *model* (or ISOLDE's currently selected model) appears to have
+a complete set of hydrogens, using the same heuristics ISOLDE's
+"Unparametrised residues" panel applies before launching a simulation. Logs
+a one-line summary and returns a dictionary with the hydrogen / heavy-atom
+counts, the H/heavy ratio, water statistics, an overall ``status``
+(``ok``, ``missing``, ``low`` or ``waters_missing``), and a
+``recommend_addh`` flag indicating whether the agent or user should run the
+ChimeraX ``addh`` command before proceeding.
+
+isolde preflight parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Syntax: isolde preflight parameters [*model*] [**forcefield** *name*]
+[**ignoreExternalBonds** *true|FALSE*]
+
+Run ISOLDE's MD-template assignment over *model* (or ISOLDE's currently
+selected model) without starting a simulation, and report any residues that
+are unparametrised or ambiguous. This is the same dry-run that the
+"Unparametrised residues" panel performs — it does not call the OpenMM
+``Context`` constructor and so cannot raise the cryptic errors that arise
+from a real simulation start.
+
+Returns a dictionary including total / matched / ambiguous / unmatched
+residue counts, a ``ready_for_simulation`` boolean, and per-residue details
+for any unmatched residues (with suggested candidate templates by name and
+by topology) and any ambiguous residues (with the list of candidate
+templates).
+
+The *forcefield* keyword defaults to ISOLDE's currently configured
+forcefield (e.g. ``amber14``); pass it explicitly to preflight against a
+different one. *ignoreExternalBonds* defaults to ``true`` to match the
+behaviour of the GUI panel.
+
 .. _sim:
 
 isolde sim

--- a/isolde/src/cmd/cmd.py
+++ b/isolde/src/cmd/cmd.py
@@ -490,3 +490,5 @@ def register_isolde(logger):
     register_isolde_param(logger)
     from chimerax.isolde.benchmark import register_isolde_benchmark
     register_isolde_benchmark(logger)
+    from chimerax.isolde.validation.cmd import register_validate_commands
+    register_validate_commands(logger)

--- a/isolde/src/cmd/cmd.py
+++ b/isolde/src/cmd/cmd.py
@@ -63,6 +63,57 @@ def isolde_select(session, model):
             return DEREGISTER
         isolde.triggers.add_handler(isolde.GUI_STARTED, select_model)
 
+def isolde_status(session):
+    '''Report ISOLDE's current state without modifying anything.
+
+    Safe to call at any time, including before ``isolde start``. Logs a
+    one-line summary and returns a dict so an agent or script can
+    programmatically confirm which model (if any) is currently selected.
+    '''
+    isolde = getattr(session, 'isolde', None)
+    log = session.logger
+
+    if isolde is None:
+        log.info('ISOLDE status: not started. Run "isolde start" first.')
+        return {
+            'isolde_started': False,
+            'selected_model': None,
+            'selected_model_spec': None,
+            'selected_model_name': None,
+            'simulation_running': False,
+            'forcefield': None,
+            'sim_fidelity_mode': None,
+        }
+
+    m = isolde.selected_model
+    sp = isolde.sim_params
+    ff_name = getattr(sp, 'forcefield', None)
+    fidelity = getattr(sp, 'sim_fidelity_mode', None)
+    sim_running = bool(isolde.simulation_running)
+
+    if m is None:
+        log.warning(
+            'ISOLDE status: started, but no model is selected. '
+            'Run "isolde select <model>" before validation or simulation.'
+        )
+    else:
+        log.info(
+            'ISOLDE status: model {} ({}) selected; forcefield={}; '
+            'simulation_running={}.'.format(
+                m.atomspec, m.name, ff_name, sim_running
+            )
+        )
+
+    return {
+        'isolde_started': True,
+        'selected_model': m.id_string if m is not None else None,
+        'selected_model_spec': m.atomspec if m is not None else None,
+        'selected_model_name': m.name if m is not None else None,
+        'simulation_running': sim_running,
+        'forcefield': ff_name,
+        'sim_fidelity_mode': fidelity,
+    }
+
 def isolde_sim(session, cmd, atoms=None, discard_to=None):
     '''
     Start, stop or pause an interactive simulation.
@@ -370,6 +421,12 @@ def register_isolde(logger):
         )
         register('isolde select', desc, isolde_select, logger=logger)
 
+    def register_isolde_status():
+        desc = CmdDesc(
+            synopsis="Report ISOLDE's current state (selected model, sim status, forcefield)"
+        )
+        register('isolde status', desc, isolde_status, logger=logger)
+
     def register_isolde_report():
         desc = CmdDesc(
             optional=[('report', BoolArg),],
@@ -462,6 +519,7 @@ def register_isolde(logger):
     register_isolde_start()
     register_isolde_set()
     register_isolde_select()
+    register_isolde_status()
     register_isolde_sim()
     register_isolde_report()
     register_isolde_ignore()

--- a/isolde/src/cmd/cmd.py
+++ b/isolde/src/cmd/cmd.py
@@ -94,7 +94,7 @@ def isolde_status(session):
     if m is None:
         log.warning(
             'ISOLDE status: started, but no model is selected. '
-            'Run "isolde select <model>" before validation or simulation.'
+            'Run "isolde select <model>" before preflight checks or simulation.'
         )
     else:
         log.info(
@@ -548,5 +548,5 @@ def register_isolde(logger):
     register_isolde_param(logger)
     from chimerax.isolde.benchmark import register_isolde_benchmark
     register_isolde_benchmark(logger)
-    from chimerax.isolde.validation.cmd import register_validate_commands
-    register_validate_commands(logger)
+    from chimerax.isolde.validation.cmd import register_preflight_commands
+    register_preflight_commands(logger)

--- a/isolde/src/openmm/cmd.py
+++ b/isolde/src/openmm/cmd.py
@@ -13,11 +13,98 @@ def reset_forcefield(session):
         session.isolde.forcefield_mgr.reset(clear_cache=True)
 
 
+def _residue_names_from_ffxml(xml_file, resname_prefix=''):
+    '''Parse an OpenMM ffXML file and return the list of residue names it
+    defines, optionally prefixed.'''
+    import xml.etree.ElementTree as ET
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+    names = []
+    residues_section = root.find('Residues')
+    if residues_section is not None:
+        for residue in residues_section.findall('Residue'):
+            if 'name' in residue.attrib:
+                names.append(resname_prefix + residue.attrib['name'])
+    return names
+
+
+def _delete_residue_templates(forcefield, template_names):
+    '''Remove residue templates from an OpenMM ForceField, including their
+    entries in the topology-signature index used for fallback matching.'''
+    for name in template_names:
+        if name in forcefield._templates:
+            template = forcefield._templates[name]
+            del forcefield._templates[name]
+            from openmm.app.forcefield import _createResidueSignature
+            signature = _createResidueSignature([atom.element for atom in template.atoms])
+            if signature in forcefield._templateSignatures:
+                if template in forcefield._templateSignatures[signature]:
+                    forcefield._templateSignatures[signature].remove(template)
+
+
+def _load_user_ffxml(forcefield, file_path):
+    '''Load an OpenMM ffXML file into ``forcefield`` with the ``USER_`` prefix,
+    first removing any existing ``USER_``-prefixed templates whose names would
+    otherwise collide. Returns the list of residue names defined in the file
+    (without the ``USER_`` prefix).'''
+    residue_names = _residue_names_from_ffxml(file_path)
+    template_names = ['USER_' + n for n in residue_names]
+    _delete_residue_templates(forcefield, template_names)
+    forcefield.loadFile(file_path, resname_prefix='USER_')
+    return residue_names
+
+
+def isolde_load_parameters(session, file_path):
+    '''
+    Load OpenMM ffXML residue parameters into ISOLDE's active forcefield.
+    Mirrors the "Load residue parameters" GUI button: any existing USER_
+    templates with colliding names are replaced.
+    '''
+    from chimerax.isolde.cmd.cmd import isolde_start, block_if_sim_running
+    from chimerax.core.errors import UserError
+    import os
+
+    block_if_sim_running(session)
+    isolde = isolde_start(session)
+    if isolde is None:
+        raise UserError('isolde load parameters requires the ISOLDE GUI session.')
+
+    file_path = os.path.expanduser(file_path)
+    if not os.path.isfile(file_path):
+        raise UserError(f'No such file: {file_path}')
+
+    ff = isolde.forcefield_mgr[isolde.sim_params.forcefield]
+    try:
+        residue_names = _load_user_ffxml(ff, file_path)
+    except ValueError as e:
+        session.logger.warning(f'Failed to load {file_path}: {e}')
+        return
+
+    if residue_names:
+        formatted = ', '.join(residue_names)
+        session.logger.info(
+            f'ISOLDE: loaded residue parameters from {file_path} '
+            f'({len(residue_names)} residue{"s" if len(residue_names) != 1 else ""} '
+            f'registered as USER_): {formatted}'
+        )
+    else:
+        session.logger.warning(
+            f'ISOLDE: loaded {file_path}, but it contained no <Residue> definitions.'
+        )
+
 
 def register_ff_cmd(logger):
-    from chimerax.core.commands import register, CmdDesc
+    from chimerax.core.commands import register, CmdDesc, FileNameArg
     register('isolde reset forcefield',
         CmdDesc(synopsis='Reset the forcefield and regenerate from ffXML files'),
         reset_forcefield,
         logger=logger
+    )
+    register('isolde load parameters',
+        CmdDesc(
+            required=[('file_path', FileNameArg)],
+            synopsis='Load OpenMM ffXML residue parameters into ISOLDE'
+        ),
+        isolde_load_parameters,
+        logger=logger,
     )

--- a/isolde/src/openmm/openmm_interface.py
+++ b/isolde/src/openmm/openmm_interface.py
@@ -3022,6 +3022,23 @@ def find_residue_templates(residues, forcefield, ligand_db = None, logger=None):
         if rtype is not None:
             templates[c_i] = rtype
 
+    # Check USER_ templates for ALL residues first, regardless of polymer type.
+    # This ensures that custom templates loaded via "Load residue parameters"
+    # (which are registered with the USER_ prefix by loadFile's resname_prefix
+    # argument) are found even for residues that ChimeraX classifies as polymer
+    # (PT_AMINO_ACID / PT_NUCLEIC) rather than PT_NONE.  Without this pre-pass,
+    # terminal caps and other non-standard polymer residues fall through to
+    # signature-based matching and can collide with built-in templates such as
+    # ACEcyc or NHE, producing an "ambiguous template" error.
+    for name in numpy.unique(residues.names):
+        if name == 'HOH':
+            continue
+        user_name = 'USER_{}'.format(name)
+        if user_name in template_names:
+            indices = numpy.where(residues.names == name)[0]
+            for i in indices:
+                templates[i] = user_name
+
     from chimerax.atomic import Residue
     ligands = residues[residues.polymer_types == Residue.PT_NONE]
     ligands = ligands[ligands.names != 'HOH']
@@ -3034,9 +3051,7 @@ def find_residue_templates(residues, forcefield, ligand_db = None, logger=None):
     for name in names:
         user_name = 'USER_{}'.format(name)
         if user_name in template_names:
-            indices = numpy.where(residues.names == name)[0]
-            for i in indices:
-                templates[i] = user_name
+            # Already handled by the pre-pass above; skip.
             continue
 
         if name in known_sugars:

--- a/isolde/src/ui/general_tab/param.py
+++ b/isolde/src/ui/general_tab/param.py
@@ -47,48 +47,17 @@ class ParameteriseDialog(UI_Panel_Base):
         from chimerax.core.selection import SELECTION_CHANGED
         self._chimerax_trigger_handlers.append(self.session.triggers.add_handler(SELECTION_CHANGED, self._selection_changed_cb))
     
-    def _get_residue_names_from_xml(self, xml_file, resname_prefix=''):
-        """Parse XML file and return list of residue names"""
-        import xml.etree.ElementTree as ET
-        tree = ET.parse(xml_file)
-        root = tree.getroot()
-        names = []
-        residues_section = root.find('Residues')
-        if residues_section is not None:
-            for residue in residues_section.findall('Residue'):
-                if 'name' in residue.attrib:
-                    names.append(resname_prefix + residue.attrib['name'])
-        return names
-    
-    def _delete_residue_templates(self, forcefield, template_names):
-        """Delete residue templates from forcefield if they exist"""
-        for name in template_names:
-            if name in forcefield._templates:
-                template = forcefield._templates[name]
-                # Remove from main template dict
-                del forcefield._templates[name]
-                # Remove from signature index
-                from openmm.app.forcefield import _createResidueSignature
-                signature = _createResidueSignature([atom.element for atom in template.atoms])
-                if signature in forcefield._templateSignatures:
-                    if template in forcefield._templateSignatures[signature]:
-                        forcefield._templateSignatures[signature].remove(template)
-    
     def _load_params_cb(self, *_):
         files = self._choose_ff_files(self.load_defs_button)
-        if files is not None and len(files):
-            ff = self.isolde.forcefield_mgr[self.isolde.sim_params.forcefield]
-            for f in files:
-                try:
-                    # Extract residue names and delete existing templates
-                    template_names = self._get_residue_names_from_xml(f, resname_prefix='USER_')
-                    self._delete_residue_templates(ff, template_names)
-                    # Now load the file (will succeed since templates are deleted)
-                    ff.loadFile(f, resname_prefix='USER_')
-                except ValueError as e:
-                    self.session.logger.warning(f'Failed to add {f}: {str(e)}')
-                except:
-                    raise
+        if not files:
+            return
+        from chimerax.isolde.openmm.cmd import _load_user_ffxml
+        ff = self.isolde.forcefield_mgr[self.isolde.sim_params.forcefield]
+        for f in files:
+            try:
+                _load_user_ffxml(ff, f)
+            except ValueError as e:
+                self.session.logger.warning(f'Failed to add {f}: {str(e)}')
 
     def _choose_ff_files(self, parent):
         caption = 'Choose one or more ffXML files'

--- a/isolde/src/ui/general_tab/param.py
+++ b/isolde/src/ui/general_tab/param.py
@@ -47,12 +47,43 @@ class ParameteriseDialog(UI_Panel_Base):
         from chimerax.core.selection import SELECTION_CHANGED
         self._chimerax_trigger_handlers.append(self.session.triggers.add_handler(SELECTION_CHANGED, self._selection_changed_cb))
     
+    def _get_residue_names_from_xml(self, xml_file, resname_prefix=''):
+        """Parse XML file and return list of residue names"""
+        import xml.etree.ElementTree as ET
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        names = []
+        residues_section = root.find('Residues')
+        if residues_section is not None:
+            for residue in residues_section.findall('Residue'):
+                if 'name' in residue.attrib:
+                    names.append(resname_prefix + residue.attrib['name'])
+        return names
+    
+    def _delete_residue_templates(self, forcefield, template_names):
+        """Delete residue templates from forcefield if they exist"""
+        for name in template_names:
+            if name in forcefield._templates:
+                template = forcefield._templates[name]
+                # Remove from main template dict
+                del forcefield._templates[name]
+                # Remove from signature index
+                from openmm.app.forcefield import _createResidueSignature
+                signature = _createResidueSignature([atom.element for atom in template.atoms])
+                if signature in forcefield._templateSignatures:
+                    if template in forcefield._templateSignatures[signature]:
+                        forcefield._templateSignatures[signature].remove(template)
+    
     def _load_params_cb(self, *_):
         files = self._choose_ff_files(self.load_defs_button)
         if files is not None and len(files):
             ff = self.isolde.forcefield_mgr[self.isolde.sim_params.forcefield]
             for f in files:
                 try:
+                    # Extract residue names and delete existing templates
+                    template_names = self._get_residue_names_from_xml(f, resname_prefix='USER_')
+                    self._delete_residue_templates(ff, template_names)
+                    # Now load the file (will succeed since templates are deleted)
                     ff.loadFile(f, resname_prefix='USER_')
                 except ValueError as e:
                     self.session.logger.warning(f'Failed to add {f}: {str(e)}')

--- a/isolde/src/validation/cmd.py
+++ b/isolde/src/validation/cmd.py
@@ -141,3 +141,272 @@ def register_rama(logger):
     )
     register('rama stop', undesc, unrama, logger=logger)
     create_alias('~rama', 'rama stop $*', logger=logger)
+
+
+# ---------------------------------------------------------------------------
+# Read-only ``isolde validate`` commands.
+#
+# These commands let an agent (or scripted user) ask whether a model is ready
+# for an ISOLDE simulation without actually trying to start one. They are safe
+# to call at any time: they never construct an OpenMM ``Context``, never raise
+# on missing parameters, and never modify the model.
+# ---------------------------------------------------------------------------
+
+from chimerax.core.errors import UserError
+
+from .unparameterised import (
+    H_TO_HEAVY_ATOM_THRESHOLD_RATIO,
+    suspiciously_low_h,
+    waters_without_h,
+)
+
+
+def _resolve_model(session, model):
+    if model is not None:
+        return model
+    isolde = getattr(session, 'isolde', None)
+    if isolde is not None and isolde.selected_model is not None:
+        return isolde.selected_model
+    raise UserError(
+        'No model specified and no model is currently selected in ISOLDE. '
+        'Either pass a model argument or run "isolde select <model>" first.'
+    )
+
+
+def _residue_summary(r):
+    return {
+        'chain_id': r.chain_id,
+        'name': r.name,
+        'number': int(r.number),
+        'insertion_code': r.insertion_code,
+        'spec': r.atomspec,
+    }
+
+
+def _residue_label(r):
+    icode = r.insertion_code.strip()
+    return '/{} {} {}{}'.format(r.chain_id, r.name, r.number, icode)
+
+
+def isolde_validate_hydrogens(session, model=None):
+    '''
+    Check whether ``model`` (or ISOLDE's currently selected model) appears to
+    have a complete set of hydrogens, using the same heuristics ISOLDE's
+    "Unparametrised residues" panel applies before launching a simulation.
+
+    Does not modify the model and does not start a simulation. Returns a dict
+    suitable for programmatic consumption; also logs a one-line summary.
+    '''
+    m = _resolve_model(session, model)
+    residues = m.residues
+    atoms = residues.atoms
+    enames = atoms.element_names
+    n_h = int((enames == 'H').sum())
+    n_heavy = int((enames != 'H').sum())
+    ratio = (n_h / n_heavy) if n_heavy else 0.0
+    waters = residues[residues.names == 'HOH']
+    waters_missing = sum(1 for w in waters if len(w.atoms) != 3)
+
+    if n_h == 0:
+        status = 'missing'
+        message = 'No hydrogens present.'
+    elif suspiciously_low_h(residues):
+        message = (
+            'H/heavy-atom ratio {:.2f} is below the expected threshold of {:.2f}.'
+            .format(ratio, H_TO_HEAVY_ATOM_THRESHOLD_RATIO)
+        )
+        status = 'low'
+    elif waters_without_h(residues):
+        status = 'waters_missing'
+        message = '{} water residue(s) are missing one or both hydrogens.'.format(
+            waters_missing
+        )
+    else:
+        status = 'ok'
+        message = 'Hydrogens look complete.'
+
+    log = session.logger
+    summary = (
+        'ISOLDE hydrogen check ({}): {} ({} H / {} heavy, ratio {:.2f}; '
+        '{} waters, {} missing H).'.format(
+            m.atomspec, message, n_h, n_heavy, ratio, len(waters), waters_missing
+        )
+    )
+    if status == 'ok':
+        log.info(summary)
+    else:
+        log.warning(summary)
+        log.info('Recommendation: run "addh" before starting an ISOLDE simulation.')
+
+    return {
+        'model': m.atomspec,
+        'status': status,
+        'message': message,
+        'hydrogen_count': n_h,
+        'heavy_atom_count': n_heavy,
+        'ratio': ratio,
+        'water_count': int(len(waters)),
+        'waters_missing_hydrogens': int(waters_missing),
+        'recommend_addh': status != 'ok',
+    }
+
+
+def _get_forcefield(session, ff_name):
+    '''
+    Return ``(forcefield, ligand_db, ff_name)``. Reuses ISOLDE's cached
+    ``ForcefieldMgr`` if available so we don't reload the forcefield from
+    disk; otherwise creates a temporary local manager. Either way no
+    simulation is started.
+    '''
+    isolde = getattr(session, 'isolde', None)
+    if isolde is not None:
+        ffmgr = isolde.forcefield_mgr
+        if ff_name is None:
+            ff_name = isolde.sim_params.forcefield
+    else:
+        from ..openmm.forcefields import ForcefieldMgr
+        ffmgr = ForcefieldMgr(session)
+        if ff_name is None:
+            from ..constants import defaults
+            ff_name = defaults.OPENMM_FORCEFIELD
+    ff = ffmgr[ff_name]
+    ligand_db = ffmgr.ligand_db(ff_name)
+    return ff, ligand_db, ff_name
+
+
+def isolde_validate_parameters(session, model=None, forcefield=None,
+        ignore_external_bonds=True):
+    '''
+    Run ISOLDE's MD-template assignment over the given model (or ISOLDE's
+    currently selected model) without starting a simulation, and report any
+    residues that are unparametrised or ambiguous.
+
+    This is the same dry-run that the "Unparametrised residues" panel
+    performs - it does not call the OpenMM ``Context`` constructor and so
+    cannot raise the cryptic errors that arise from a real simulation start.
+
+    Parameters
+    ----------
+    model : AtomicStructure, optional
+        The model to check. Defaults to ISOLDE's currently selected model.
+    forcefield : str, optional
+        The forcefield name to check against (e.g. ``'amber14'``). Defaults
+        to ISOLDE's currently configured forcefield.
+    ignore_external_bonds : bool, default True
+        Whether to ignore external bonds when matching residues to templates.
+        ``True`` matches the behaviour used by the GUI panel.
+
+    Returns
+    -------
+    dict
+        Summary including counts and per-residue details for any unmatched or
+        ambiguous residues.
+    '''
+    m = _resolve_model(session, model)
+    log = session.logger
+
+    ff, ligand_db, ff_name = _get_forcefield(session, forcefield)
+
+    from chimerax.atomic import Residues
+    residues = Residues(sorted(m.residues,
+        key=lambda r: (r.chain_id, r.number, r.insertion_code)))
+
+    from ..openmm.openmm_interface import (
+        find_residue_templates, create_openmm_topology
+    )
+    template_dict = find_residue_templates(
+        residues, ff, ligand_db=ligand_db, logger=log
+    )
+    top, residue_templates = create_openmm_topology(
+        residues.atoms, template_dict
+    )
+    unique, ambiguous, unmatched = ff.assignTemplates(
+        top, ignoreExternalBonds=ignore_external_bonds,
+        explicit_templates=residue_templates,
+    )
+
+    unmatched_info = []
+    for r in unmatched:
+        cx_res = residues[r.index]
+        info = _residue_summary(cx_res)
+        # Suggest possible templates so the agent has something actionable.
+        try:
+            by_name, by_comp = ff.find_possible_templates(r)
+        except Exception:
+            by_name, by_comp = [], []
+        info['candidates_by_name'] = [
+            {'template': t, 'score': float(s)} for (t, s) in by_name
+        ]
+        info['candidates_by_topology'] = [
+            {'template': t, 'score': float(s)} for (t, s) in by_comp
+        ]
+        unmatched_info.append(info)
+
+    ambiguous_info = []
+    for r, template_info in ambiguous.items():
+        cx_res = residues[r.index]
+        info = _residue_summary(cx_res)
+        info['candidates'] = [t[0].name for t in template_info]
+        ambiguous_info.append(info)
+
+    n_total = len(residues)
+    n_unique = len(unique)
+    n_ambig = len(ambiguous)
+    n_unmatched = len(unmatched)
+
+    header = (
+        'ISOLDE parameter check ({}, forcefield {}): '
+        '{} residues, {} matched, {} ambiguous, {} unmatched.'.format(
+            m.atomspec, ff_name, n_total, n_unique, n_ambig, n_unmatched
+        )
+    )
+    if n_unmatched == 0 and n_ambig == 0:
+        log.info(header)
+    else:
+        log.warning(header)
+        if unmatched_info:
+            log.info('  Unmatched: ' + ', '.join(
+                _residue_label(residues[u.index]) for u in unmatched
+            ))
+        if ambiguous_info:
+            log.info('  Ambiguous: ' + ', '.join(
+                _residue_label(residues[r.index]) for r in ambiguous
+            ))
+
+    return {
+        'model': m.atomspec,
+        'forcefield': ff_name,
+        'ignore_external_bonds': bool(ignore_external_bonds),
+        'n_total': int(n_total),
+        'n_matched': int(n_unique),
+        'n_ambiguous': int(n_ambig),
+        'n_unmatched': int(n_unmatched),
+        'ready_for_simulation': n_unmatched == 0 and n_ambig == 0,
+        'unmatched': unmatched_info,
+        'ambiguous': ambiguous_info,
+    }
+
+
+def register_validate_commands(logger):
+    from chimerax.core.commands import (
+        register, CmdDesc, BoolArg, StringArg,
+    )
+    from ..cmd.argspec import IsoldeStructureArg
+
+    desc_h = CmdDesc(
+        optional=[('model', IsoldeStructureArg)],
+        synopsis='Check whether the model has plausible hydrogens',
+    )
+    register('isolde validate hydrogens', desc_h,
+        isolde_validate_hydrogens, logger=logger)
+
+    desc_p = CmdDesc(
+        optional=[('model', IsoldeStructureArg)],
+        keyword=[
+            ('forcefield', StringArg),
+            ('ignore_external_bonds', BoolArg),
+        ],
+        synopsis='Check whether all residues match an MD forcefield template',
+    )
+    register('isolde validate parameters', desc_p,
+        isolde_validate_parameters, logger=logger)

--- a/isolde/src/validation/cmd.py
+++ b/isolde/src/validation/cmd.py
@@ -144,7 +144,7 @@ def register_rama(logger):
 
 
 # ---------------------------------------------------------------------------
-# Read-only ``isolde validate`` commands.
+# Read-only ``isolde preflight`` commands.
 #
 # These commands let an agent (or scripted user) ask whether a model is ready
 # for an ISOLDE simulation without actually trying to start one. They are safe
@@ -188,11 +188,12 @@ def _residue_label(r):
     return '/{} {} {}{}'.format(r.chain_id, r.name, r.number, icode)
 
 
-def isolde_validate_hydrogens(session, model=None):
+def isolde_preflight_hydrogens(session, model=None):
     '''
-    Check whether ``model`` (or ISOLDE's currently selected model) appears to
-    have a complete set of hydrogens, using the same heuristics ISOLDE's
-    "Unparametrised residues" panel applies before launching a simulation.
+    Preflight check: does ``model`` (or ISOLDE's currently selected model)
+    appear to have a complete set of hydrogens for an MD simulation? Uses the
+    same heuristics ISOLDE's "Unparametrised residues" panel applies before
+    launching a simulation.
 
     Does not modify the model and does not start a simulation. Returns a dict
     suitable for programmatic consumption; also logs a one-line summary.
@@ -274,12 +275,12 @@ def _get_forcefield(session, ff_name):
     return ff, ligand_db, ff_name
 
 
-def isolde_validate_parameters(session, model=None, forcefield=None,
+def isolde_preflight_parameters(session, model=None, forcefield=None,
         ignore_external_bonds=True):
     '''
-    Run ISOLDE's MD-template assignment over the given model (or ISOLDE's
-    currently selected model) without starting a simulation, and report any
-    residues that are unparametrised or ambiguous.
+    Preflight check: run ISOLDE's MD-template assignment over the given model
+    (or ISOLDE's currently selected model) without starting a simulation, and
+    report any residues that are unparametrised or ambiguous.
 
     This is the same dry-run that the "Unparametrised residues" panel
     performs - it does not call the OpenMM ``Context`` constructor and so
@@ -387,7 +388,7 @@ def isolde_validate_parameters(session, model=None, forcefield=None,
     }
 
 
-def register_validate_commands(logger):
+def register_preflight_commands(logger):
     from chimerax.core.commands import (
         register, CmdDesc, BoolArg, StringArg,
     )
@@ -395,10 +396,10 @@ def register_validate_commands(logger):
 
     desc_h = CmdDesc(
         optional=[('model', IsoldeStructureArg)],
-        synopsis='Check whether the model has plausible hydrogens',
+        synopsis='Preflight check: does the model have plausible hydrogens for MD?',
     )
-    register('isolde validate hydrogens', desc_h,
-        isolde_validate_hydrogens, logger=logger)
+    register('isolde preflight hydrogens', desc_h,
+        isolde_preflight_hydrogens, logger=logger)
 
     desc_p = CmdDesc(
         optional=[('model', IsoldeStructureArg)],
@@ -406,7 +407,7 @@ def register_validate_commands(logger):
             ('forcefield', StringArg),
             ('ignore_external_bonds', BoolArg),
         ],
-        synopsis='Check whether all residues match an MD forcefield template',
+        synopsis='Preflight check: do all residues match an MD forcefield template?',
     )
-    register('isolde validate parameters', desc_p,
-        isolde_validate_parameters, logger=logger)
+    register('isolde preflight parameters', desc_p,
+        isolde_preflight_parameters, logger=logger)

--- a/isolde/src/validation/unparameterised.py
+++ b/isolde/src/validation/unparameterised.py
@@ -11,6 +11,32 @@ from chimerax.isolde import atomic
 from Qt.QtCore import Qt
 USER_ROLE = Qt.ItemDataRole.UserRole
 
+H_TO_HEAVY_ATOM_THRESHOLD_RATIO = 0.5
+
+def suspiciously_low_h(residues):
+    '''
+    Heuristic: returns True if the H/heavy-atom ratio of the given residues is
+    below ``H_TO_HEAVY_ATOM_THRESHOLD_RATIO``. Always False if there are no
+    heavy atoms.
+    '''
+    enames = residues.atoms.element_names
+    n_h = (enames == 'H').sum()
+    n_heavy = (enames != 'H').sum()
+    if n_heavy == 0:
+        return False
+    return (n_h / n_heavy) < H_TO_HEAVY_ATOM_THRESHOLD_RATIO
+
+def waters_without_h(residues):
+    '''
+    Returns True if any residue named 'HOH' in the given set has other than
+    three atoms (i.e. is missing one or both hydrogens).
+    '''
+    waters = residues[residues.names == 'HOH']
+    for w in waters:
+        if len(w.atoms) != 3:
+            return True
+    return False
+
 class Unparameterised_Residues_Mgr:
 
     def __init__(self, isolde):
@@ -53,18 +79,13 @@ class Unparameterised_Residues_Mgr:
         self._stub_frame.show()
         self._main_frame.hide()
 
-    H_TO_HEAVY_ATOM_THRESHOLD_RATIO = 0.5
+    H_TO_HEAVY_ATOM_THRESHOLD_RATIO = H_TO_HEAVY_ATOM_THRESHOLD_RATIO
+
     def suspiciously_low_h(self, residues):
-        hydrogens = residues.atoms[residues.atoms.element_names=='H']
-        heavy_atoms = residues.atoms[residues.atoms.element_names!='H']
-        if len(hydrogens)/len(heavy_atoms) < self.H_TO_HEAVY_ATOM_THRESHOLD_RATIO:
-            return True
-    
+        return suspiciously_low_h(residues)
+
     def waters_without_h(self, residues):
-        waters = residues[residues.names=='HOH']
-        for w in waters:
-            if len(w.atoms) != 3:
-                return True
+        return waters_without_h(residues)
 
     def _update_unparameterised_residues_list(self, *_, ff=None, ambiguous=None, unmatched=None, residues=None):
         table = self._residue_table


### PR DESCRIPTION
This PR adds four new commands:
- isolde validate hydrogens
- isolde validate parameters
- isolde load parameters
- isolde status

This has allowed me to get my agent to setup an isolde simulation from scratch via the ChimeraX MCP bridge.