### PR TITLE
Add preflight commands for disulfides and altlocs.

### DIFF
--- a/isolde/src/atomic/building/build_utils.py
+++ b/isolde/src/atomic/building/build_utils.py
@@ -353,6 +353,35 @@ def create_disulfide(cys1, cys2):
     from chimerax.atomic.struct_edit import add_bond
     add_bond(s1, s2)
 
+
+def create_all_sensible_disulfides(model, logger=None):
+    '''
+    Create disulfide bonds for every pair of cysteines in ``model`` whose
+    SG atoms are close enough to be disulfide-bonded but currently lack an
+    SG-SG bond. Cysteines that cluster in groups of three or more are not
+    bonded automatically and are returned as the "ambiguous" set so the
+    caller can warn or display them as appropriate.
+
+    Returns ``(possible_pairs_created, ambiguous_clusters)`` where
+    ``possible_pairs_created`` is the set of cysteine-residue pairs that
+    were actually bonded by this call, and ``ambiguous_clusters`` is the
+    set of cysteine-residue groups that were left untouched.
+    '''
+    _current, possible, ambiguous = current_and_possible_disulfides(model)
+    for cys_pair in possible:
+        create_disulfide(*cys_pair)
+    if logger is not None and possible:
+        logger.info(
+            'Created disulfide bonds between the following residues:\n{}'.format(
+                '; '.join([
+                    '-'.join(['{}{}{}'.format(c.chain_id, c.number, c.insertion_code)
+                              for c in p])
+                    for p in possible
+                ])
+            )
+        )
+    return possible, ambiguous
+
 _CYS_ALIGN_ATOMS=('CA', 'CB', 'SG')
 def break_disulfide(cys1, cys2):
     from chimerax.core.errors import UserError

--- a/isolde/src/atomic/util.py
+++ b/isolde/src/atomic/util.py
@@ -1,5 +1,28 @@
 rings = ('PHE','TYR') #,'TYS','PTR') <- non-standard amino acids currently throw a RuntimeError (25/10/2021)
 
+
+def clear_altlocs(model, logger=None):
+    '''
+    Drop all alternate conformations from ``model`` and reset the affected
+    atoms' occupancies to 1.0. Mirrors the action ISOLDE offers via the
+    auto-popup the first time a model with alt locs is selected.
+
+    Returns the number of atoms that had alternate conformers before the
+    call.
+    '''
+    atoms_with_alt_locs = model.atoms[model.atoms.num_alt_locs > 0]
+    n = int(len(atoms_with_alt_locs))
+    if n:
+        model.delete_alt_locs()
+        atoms_with_alt_locs.occupancies = 1
+        if logger is not None:
+            logger.info(
+                'Removed all altlocs in #{} ({} atom(s)) and reset associated '
+                'occupancies to 1.'.format(model.id_string, n)
+            )
+    return n
+
+
 def correct_pseudosymmetric_sidechain_atoms(session, residues):
     '''
     Protein sidechain atom names follow strict rules dictating the names of atoms 

--- a/isolde/src/cmd/cmd.py
+++ b/isolde/src/cmd/cmd.py
@@ -374,6 +374,69 @@ def isolde_jump(session, direction="next"):
     rs = get_stepper(m)
     rs.incr_chain(direction)
 
+
+def isolde_add_disulfides_auto(session, model=None):
+    '''
+    Create disulfide bonds for every pair of cysteines whose SG atoms are
+    close enough to be disulfide-bonded but currently lack an SG-SG bond
+    (the "possible" set from ``isolde preflight disulfides``).
+
+    Cysteines that cluster in groups of three or more are *not* bonded
+    automatically — those need manual triage and are reported as a warning.
+
+    Setting the per-model "checked" flag here also suppresses the auto-popup
+    that would otherwise fire on the next ``isolde select`` for the model.
+    '''
+    block_if_sim_running(session)
+    from ..validation.cmd import _resolve_model
+    m = _resolve_model(session, model)
+    log = session.logger
+    from ..atomic.building.build_utils import create_all_sensible_disulfides
+    possible, ambiguous = create_all_sensible_disulfides(m, logger=log)
+    if not possible:
+        log.info('ISOLDE: no new disulfide bonds to create.')
+    if ambiguous:
+        warn_str = (
+            'The following groups of cysteines are clustered too close to '
+            'automatically assign disulfide bonding and should be checked '
+            'manually:\n{}'
+        ).format('; '.join([
+            ', '.join(['{}{}{}'.format(c.chain_id, c.number, c.insertion_code)
+                       for c in residues])
+            for residues in ambiguous
+        ]))
+        log.warning(warn_str)
+    m._isolde_disulfide_check_done = True
+    return {
+        'model': m.atomspec,
+        'created': int(len(possible)),
+        'ambiguous': int(len(ambiguous)),
+    }
+
+
+def isolde_clear_altlocs(session, model=None):
+    '''
+    Drop all alternate conformations from ``model`` (or ISOLDE's currently
+    selected model) and reset the affected atoms' occupancies to 1.0. This
+    mirrors the action ISOLDE offers via the auto-popup the first time a
+    model with alt locs is selected.
+    '''
+    block_if_sim_running(session)
+    from ..validation.cmd import _resolve_model
+    m = _resolve_model(session, model)
+    log = session.logger
+    from ..atomic.util import clear_altlocs
+    n = clear_altlocs(m, logger=log)
+    if n == 0:
+        log.info('ISOLDE: model {} has no alternate conformations to clear.'
+            .format(m.atomspec))
+    m._isolde_altloc_check_done = True
+    return {
+        'model': m.atomspec,
+        'atoms_cleared': n,
+    }
+
+
 def register_isolde(logger):
     from chimerax.core.commands import (
         register, CmdDesc,
@@ -516,6 +579,26 @@ def register_isolde(logger):
         from .shorthand import register_isolde_shorthand_commands
         register('isolde shorthand', desc, register_isolde_shorthand_commands, logger=logger)
 
+    def register_isolde_add_disulfides_auto():
+        from .argspec import IsoldeStructureArg
+        desc = CmdDesc(
+            optional=[('model', IsoldeStructureArg)],
+            synopsis=('Create disulfide bonds for every cysteine pair within '
+                'disulfide-bonding distance that is not already bonded'),
+        )
+        register('isolde add disulfides auto', desc,
+            isolde_add_disulfides_auto, logger=logger)
+
+    def register_isolde_clear_altlocs():
+        from .argspec import IsoldeStructureArg
+        desc = CmdDesc(
+            optional=[('model', IsoldeStructureArg)],
+            synopsis=('Drop all alternate conformations from the model and '
+                'reset the affected atoms\' occupancies to 1.0'),
+        )
+        register('isolde clear altlocs', desc,
+            isolde_clear_altlocs, logger=logger)
+
     register_isolde_start()
     register_isolde_set()
     register_isolde_select()
@@ -530,6 +613,8 @@ def register_isolde(logger):
     register_isolde_jump()
     register_isolde_change_b()
     register_isolde_shorthand()
+    register_isolde_add_disulfides_auto()
+    register_isolde_clear_altlocs()
     from chimerax.isolde.remote_control import register_remote_commands
     register_remote_commands(logger)
     from chimerax.isolde.restraints.cmd import register_isolde_restrain

--- a/isolde/src/isolde.py
+++ b/isolde/src/isolde.py
@@ -800,16 +800,23 @@ class Isolde():
 
         with session.triggers.block_trigger('remove models'), session.triggers.block_trigger('add models'):
             if not getattr(m, 'isolde_initialized', False):
-                atoms_with_alt_locs = m.atoms[m.atoms.num_alt_locs>0]
-                if len(atoms_with_alt_locs):
-                    from .dialog import choice_warning
-                    result = choice_warning(f'This model contains {len(atoms_with_alt_locs)} atoms with alternate '
-                        'conformers. ISOLDE cannot currently see these, but they will be carried through to the '
-                        'output model. In most cases it is best to remove them. Would you like to do so now?')
-                    if result:
-                        m.delete_alt_locs()
-                        atoms_with_alt_locs.occupancies = 1
-                        self.session.logger.info(f'Removed all altlocs in #{m.id_string} and reset associated occupancies to 1.')
+                # Skip the alt-loc popup if "isolde preflight altlocs" or
+                # "isolde clear altlocs" has already been run for this model:
+                # they set this flag once the situation has been acknowledged
+                # (or resolved), which lets agent-driven setup handle the
+                # question through a chat round-trip instead of a blocking
+                # GUI dialog.
+                if not getattr(m, '_isolde_altloc_check_done', False):
+                    atoms_with_alt_locs = m.atoms[m.atoms.num_alt_locs>0]
+                    if len(atoms_with_alt_locs):
+                        from .dialog import choice_warning
+                        result = choice_warning(f'This model contains {len(atoms_with_alt_locs)} atoms with alternate '
+                            'conformers. ISOLDE cannot currently see these, but they will be carried through to the '
+                            'output model. In most cases it is best to remove them. Would you like to do so now?')
+                        if result:
+                            from .atomic.util import clear_altlocs
+                            clear_altlocs(m, logger=self.session.logger)
+                    m._isolde_altloc_check_done = True
                 from .atomic.util import correct_pseudosymmetric_sidechain_atoms
                 correct_pseudosymmetric_sidechain_atoms(session, m.residues)
                 m.isolde_initialized = True

--- a/isolde/src/menu/model_building/disulphides/make_all_sensible_disulphides.py
+++ b/isolde/src/menu/model_building/disulphides/make_all_sensible_disulphides.py
@@ -11,18 +11,12 @@ tooltip = ('Create disulphide bonds between any free cysteine residues with disu
 def run_script(session):
     from chimerax.core.commands import run
     from chimerax.core.errors import UserError
-    from chimerax.isolde.atomic.building.build_utils import current_and_possible_disulfides, create_disulfide
+    from chimerax.isolde.atomic.building.build_utils import create_all_sensible_disulfides
     run(session, 'isolde start', log=False)
     m = session.isolde.selected_model
     if m is None:
         raise UserError('Select a model in ISOLDE first!')
-    current, possible, ambiguous = current_and_possible_disulfides(m)
-    for cys_pair in possible:
-        create_disulfide(*cys_pair)
-    if len(possible):
-        session.logger.info('Created disulfide bonds between the following residues: \n{}'.format(
-            '; '.join(['-'.join(['{}{}{}'.format (c.chain_id, c.number, c.insertion_code) for c in p]) for p in possible])
-        ))
+    _possible, ambiguous = create_all_sensible_disulfides(m, logger=session.logger)
     if len(ambiguous):
         warn_str = ('The following cysteine residues are clustered too close to '
             'automatically assign disulphide-bonded pairs. Please check manually.\n{}').format(

--- a/isolde/src/ui/main_win.py
+++ b/isolde/src/ui/main_win.py
@@ -170,7 +170,17 @@ class IsoldeMainWin(MainToolWindow):
         from chimerax.core.triggerset import DEREGISTER
         if m is None:
             return DEREGISTER
-        from chimerax.isolde.atomic.building.build_utils import current_and_possible_disulfides
+        # The "isolde preflight disulfides" / "isolde add disulfides auto"
+        # commands set this flag once the user (or a driving agent) has
+        # acknowledged the situation, so that the popup never fires again
+        # for that model. This keeps the GUI flow unchanged for interactive
+        # users while letting agent-driven setup pre-resolve the question
+        # via the preflight commands.
+        if getattr(m, '_isolde_disulfide_check_done', False):
+            return DEREGISTER
+        from chimerax.isolde.atomic.building.build_utils import (
+            current_and_possible_disulfides, create_all_sensible_disulfides
+        )
         current, possible, ambiguous = current_and_possible_disulfides(m, cutoff_distance=2.3)
         from ..dialog import generic_warning, choice_warning
         if len(possible):
@@ -178,12 +188,7 @@ class IsoldeMainWin(MainToolWindow):
                 'specified in the model metadata. Would you like to create them now?')
             result = choice_warning(warn_str, yesno=True)
             if result:
-                from chimerax.isolde.atomic.building.build_utils import create_disulfide
-                for cys_pair in possible:
-                    create_disulfide(*cys_pair)
-                self.session.logger.info('ISOLDE: created disulfide bonds between the following residues: \n{}'.format(
-                    '; '.join(['-'.join(['{}{}{}'.format (c.chain_id, c.number, c.insertion_code) for c in p]) for p in possible])
-                ))
+                create_all_sensible_disulfides(m, logger=self.session.logger)
                 if len(ambiguous):
                     from chimerax.atomic import concise_residue_spec
                     warn_base = ('The following groups of cysteines are clustered too close to automatically assign disulfide bonding and '
@@ -196,6 +201,10 @@ class IsoldeMainWin(MainToolWindow):
                         '<br>'+'<br>'.join([f'<a href="cxcmd:view {concise_residue_spec(self.session, residues)}">{residue_string(residues)}</a>' for residues in ambiguous])
                     )
                     self.session.logger.warning(log_str, is_html=True)
+        # Mark this model as checked so that subsequent ``isolde select``
+        # calls don't re-ask. The flag is also set by the preflight
+        # commands described above.
+        m._isolde_disulfide_check_done = True
         return DEREGISTER
 
 

--- a/isolde/src/validation/cmd.py
+++ b/isolde/src/validation/cmd.py
@@ -388,6 +388,137 @@ def isolde_preflight_parameters(session, model=None, forcefield=None,
     }
 
 
+def isolde_preflight_disulfides(session, model=None):
+    '''
+    Preflight check: does ``model`` (or ISOLDE's currently selected model)
+    contain pairs of cysteines whose SG atoms are close enough to be
+    disulfide-bonded but for which no SG-SG bond is currently present in the
+    model?
+
+    This is the same geometric check that fires the "create disulfides?" GUI
+    popup the first time a model is selected in ISOLDE. Calling this command
+    does *not* create any bonds, but it stamps a per-model flag so that the
+    auto-popup will not subsequently fire for the same model — i.e. running
+    this preflight is treated as the user/agent's acknowledgement of the
+    situation. Pair this with ``isolde add disulfides auto`` if you want the
+    bonds created.
+
+    Returns a dict with three lists (``current``, ``possible``, ``ambiguous``).
+    Each list entry is itself a list of residue summaries.
+    '''
+    m = _resolve_model(session, model)
+    log = session.logger
+
+    from ..atomic.building.build_utils import current_and_possible_disulfides
+    current, possible, ambiguous = current_and_possible_disulfides(
+        m, cutoff_distance=2.3
+    )
+
+    def _pair(rset):
+        return [_residue_summary(r) for r in sorted(
+            rset, key=lambda r: (r.chain_id, r.number, r.insertion_code)
+        )]
+
+    current_info = [_pair(p) for p in current]
+    possible_info = [_pair(p) for p in possible]
+    ambiguous_info = [_pair(p) for p in ambiguous]
+
+    def _label_set(rset):
+        return '-'.join(_residue_label(r) for r in sorted(
+            rset, key=lambda r: (r.chain_id, r.number, r.insertion_code)
+        ))
+
+    summary = (
+        'ISOLDE disulfide check ({}): {} existing, {} possible new, '
+        '{} ambiguous cluster(s).'.format(
+            m.atomspec, len(current), len(possible), len(ambiguous)
+        )
+    )
+    if not possible and not ambiguous:
+        log.info(summary)
+    else:
+        log.warning(summary)
+        if possible:
+            log.info('  Possible: ' + ', '.join(
+                _label_set(p) for p in possible
+            ))
+            log.info(
+                '  To create them, run "isolde add disulfides auto {}".'
+                .format(m.atomspec)
+            )
+        if ambiguous:
+            log.info('  Ambiguous (3+ cysteines clustered, manual fix required): '
+                + '; '.join(_label_set(p) for p in ambiguous))
+
+    # Calling the preflight counts as acknowledging the situation; this
+    # suppresses the GUI popup that would otherwise fire on the next frame
+    # after `isolde select`.
+    m._isolde_disulfide_check_done = True
+
+    return {
+        'model': m.atomspec,
+        'current': current_info,
+        'possible': possible_info,
+        'ambiguous': ambiguous_info,
+        'n_current': len(current),
+        'n_possible': len(possible),
+        'n_ambiguous': len(ambiguous),
+        'recommend_create': len(possible) > 0,
+    }
+
+
+def isolde_preflight_altlocs(session, model=None):
+    '''
+    Preflight check: does ``model`` (or ISOLDE's currently selected model)
+    contain atoms with alternate conformations? ISOLDE cannot see alt locs
+    during a simulation, but they are carried through to the output, so in
+    most refinement workflows they should be removed before starting.
+
+    This is the situation that triggers the "remove alt locs?" GUI popup
+    inside ``Isolde.selected_model`` the first time a model is selected.
+    Calling this preflight stamps a per-model flag so that the auto-popup
+    will not fire for the model. Pair with ``isolde clear altlocs`` to
+    actually drop them.
+
+    Returns a dict with the per-residue list and counts.
+    '''
+    m = _resolve_model(session, model)
+    log = session.logger
+
+    atoms_with_altlocs = m.atoms[m.atoms.num_alt_locs > 0]
+    n_atoms = int(len(atoms_with_altlocs))
+    affected_residues = atoms_with_altlocs.unique_residues
+    residues_info = [_residue_summary(r) for r in affected_residues]
+
+    summary = (
+        'ISOLDE altloc check ({}): {} atom(s) with alternate conformers '
+        'across {} residue(s).'.format(m.atomspec, n_atoms, len(residues_info))
+    )
+    if n_atoms == 0:
+        log.info(summary)
+    else:
+        log.warning(summary)
+        log.info('  Affected residues: ' + ', '.join(
+            _residue_label(r) for r in affected_residues
+        ))
+        log.info(
+            '  To drop alt locs and reset occupancies, run '
+            '"isolde clear altlocs {}".'.format(m.atomspec)
+        )
+
+    # See note in isolde_preflight_disulfides: the call itself acknowledges
+    # the situation and suppresses the auto-popup.
+    m._isolde_altloc_check_done = True
+
+    return {
+        'model': m.atomspec,
+        'atoms_with_altlocs': n_atoms,
+        'residues': residues_info,
+        'n_residues': len(residues_info),
+        'recommend_clear': n_atoms > 0,
+    }
+
+
 def register_preflight_commands(logger):
     from chimerax.core.commands import (
         register, CmdDesc, BoolArg, StringArg,
@@ -411,3 +542,19 @@ def register_preflight_commands(logger):
     )
     register('isolde preflight parameters', desc_p,
         isolde_preflight_parameters, logger=logger)
+
+    desc_d = CmdDesc(
+        optional=[('model', IsoldeStructureArg)],
+        synopsis=('Preflight check: are there cysteine pairs likely to need '
+            'disulfide bonds? Suppresses the corresponding GUI popup.'),
+    )
+    register('isolde preflight disulfides', desc_d,
+        isolde_preflight_disulfides, logger=logger)
+
+    desc_a = CmdDesc(
+        optional=[('model', IsoldeStructureArg)],
+        synopsis=('Preflight check: does the model contain alternate '
+            'conformers? Suppresses the corresponding GUI popup.'),
+    )
+    register('isolde preflight altlocs', desc_a,
+        isolde_preflight_altlocs, logger=logger)


### PR DESCRIPTION
This is needed for agentic control, because otherwise popup windows requiring the human to click were getting in the way.