### PR TITLE
Modular small-molecule forcefield backends + Experience level setting

### DIFF
--- a/isolde/CLAUDE.md
+++ b/isolde/CLAUDE.md
@@ -8,6 +8,28 @@ ISOLDE is a [ChimeraX](https://www.cgl.ucsf.edu/chimerax/) plugin for interactiv
 
 **Sister package required:** ChimeraX-Clipper (map handling).
 
+**ISOLDE assumes a GUI session — it is not designed to run fully headlessly.**
+Code reachable from normal interactive use (camera/mouse-mode changes, Qt
+dialogs, spotlight/OpenGL-touching commands) is free to assume
+`session.ui.is_gui` is true. An `AttributeError` from `session.ui.mouse_modes`,
+`view.render`, etc. under `--nogui` is not, by itself, a bug — do not treat
+"doesn't work headlessly" as something that generally needs fixing.
+
+The one deliberate exception is the MCP/agent remote-control surface
+(`isolde/src/remote_control/`), which does need to drive ISOLDE — including
+starting/stopping simulations via commands like `isolde sim start` — from a
+session that may have no GUI. Guard a GUI-only side effect with the existing
+`self.gui_mode` (`session.ui.is_gui`) pattern (see `isolde.py`'s
+`_set_right_mouse_mode_tug_atom`/`_sim_end_cb`) only when the code path is
+actually reachable from that surface or from a command, not preemptively
+elsewhere.
+
+Most of `isolde/src/tests/` runs headlessly (`run_chimerax.bat --nogui --exit
+--script ...`). When a test needs to exercise logic that incidentally sits
+behind a GUI-only side effect the test doesn't care about (e.g. camera
+repositioning in `navigate.py`), stub that side effect out in the test itself
+rather than adding headless support to the underlying code.
+
 ---
 
 ## Build & install
@@ -16,8 +38,10 @@ All changes — Python or C++ — require a full wheel rebuild and ChimeraX rela
 
 **Windows:**
 ```bat
-make_win.bat release clean app-install
+make_win.bat clean app-install          # daily/nightly ChimeraX
+make_win.bat release clean app-install  # stable-release ChimeraX
 ```
+The `release` token selects which ChimeraX installation to target (stable vs. daily); omit it when building against the daily build.
 
 **Linux / macOS:**
 ```sh
@@ -83,6 +107,59 @@ Do **not** modify the following without an explicit instruction to do so. They c
 
 ---
 
+## Optional ML / small-molecule parameterisation backends
+
+ISOLDE can parameterise non-polymer ligands with several optional backends,
+selected via `sim_params.forcefield` and surfaced in the **General → Forcefield**
+panel: `amber14+garnet`, `amber14+espaloma`, `amber14+espaloma-charge`,
+`amber14+openff`, `amber14+mmff`. All are built on
+`param_provider.LigandBackedParameterisationProvider` (AMBER14 for standard
+residues, the backend for ligands); `make_parameterisation_provider()` picks the
+provider(s) whose dependencies import, and greys out the rest in the UI.
+
+**Availability probes must catch `Exception`, not just `ImportError`.** These
+backends pull in native-extension stacks (torch, DGL, rdkit's C++ core) that
+fail on version mismatch with `OSError`/`FileNotFoundError`/`RuntimeError` —
+none of which subclass `ImportError`. A probe that only catches `ImportError`
+will crash ISOLDE at startup instead of cleanly greying-out the backend. See the
+`_*_available()` helpers in `param_provider.py`.
+
+**Layered-failure signature of "pip ML lib vs. the host's pinned torch."** When
+integrating a pip-installed ML dependency against ChimeraX's own (newer) torch,
+expect failures to surface one layer at a time, each invisible until the prior
+one is cleared — so test *import*, then *runtime*, then the *specific code path*
+as separate gates:
+1. **Import of a native lib fails** (e.g. DGL's `graphbolt` has no build for the
+   installed torch) → widen availability probes to `Exception`; if the failing
+   subsystem is unused, bypass it (see `espaloma_charge_provider._ensure_dgl_importable`,
+   which stubs `dgl.graphbolt` in `sys.modules` so DGL's eager import chain is
+   satisfied without executing the broken subpackage).
+2. **A transitive dep's API was removed** (e.g. `torchdata.datapipes`, gone in
+   torchdata ≥ 0.10) → the eagerly-imported subpackage is the real problem;
+   bypass it rather than chasing the leaf import.
+3. **A serialization/policy change bites at runtime** (e.g. PyTorch ≥ 2.6
+   defaults `torch.load` to `weights_only=True`, rejecting pickled `nn.Module`
+   checkpoints) → a runtime-only failure that import-testing cannot catch, which
+   is exactly why per-stage smoke tests matter.
+
+**Charged ligands:** the rdkit-based providers infer bond orders from 3D
+geometry with `DetermineBondOrders(mol, charge=0)` — they assume a **neutral**
+ligand. Charged species (e.g. GTP at −8) fail bond perception and fall back to
+AMBER14. This is a known limitation, not a bug; the fallback is safe.
+
+---
+
+## Live editing: atoms and residues are never stable
+
+The user can add or delete atoms/residues (and bonds) at essentially any point during an ISOLDE session — via ChimeraX's own editing commands, ISOLDE's model-building tools, or interactively mid-simulation. `Atom`/`Residue`/`Bond` objects are thin Python wrappers over C++ objects; deleting the underlying structure does not (by itself) stop a stale Python reference from existing. Dereferencing a deleted atomic object does not reliably raise a catchable Python exception — it can crash ChimeraX outright (null/dangling pointer read), which is far worse than an unhandled exception.
+
+Guidance for any code (existing or new) that touches atomic objects:
+- Don't hold onto `Atom`/`Residue`/`Bond` objects, or index positions into a `Collection`, across any interval where user interaction or Qt event-loop processing could occur (a callback, a trigger handler, a stored instance attribute meant to be read later). Re-fetch fresh collections at the point of use instead.
+- Before dereferencing anything held across time (a model, manager, or residue stashed on `self` or in a closure), check `.deleted` first — this is already the established pattern throughout the codebase (see `isolde.py`, `openmm_interface.py`, `navigate.py`, `molobject.py`).
+- Prefer ChimeraX's own attribute-registration mechanism (`register_attr` + get/set on the object itself) for any per-atom/per-residue data you need to persist, rather than a separate Python-side `{atom: value}` dict keyed by object identity — the former is tied to the object's own lifecycle and cannot go stale into a dangling reference; the latter can silently hold a reference to something already deleted.
+
+---
+
 ## Common task patterns
 
 **New CLI command:**
@@ -96,6 +173,31 @@ Do **not** modify the following without an explicit instruction to do so. They c
 - User-facing docs live in `docs/source/` as Sphinx RST files
 - Build with `make docs` (requires LaTeX for PDF output)
 - Docstrings use triple-quoted format with parameter descriptions
+
+---
+
+## Change summaries
+
+When summarising a set of file changes at the end of a task, use a three-column table (the third column
+header is left blank):
+
+| File | Status |  |
+|---|---|---|
+| `src/foo.py` | New | *** |
+| `src/qux.py` | Refactor | ** |
+| `src/baz.py` | Added guard clause | * |
+| `src/bar.py` | 1-line fix |  |
+
+- **File** — path relative to the working directory, as a markdown link.
+- **Status** — plain-English description of what changed (e.g. "New", "Boot provider swapped", "CMAP fix").
+- **(third column, unlabelled)** — a magnitude marker for how big the change was. Let *N* be the number
+  of lines substantively added or changed in the file (purely **moved** code counts as zero regardless of
+  line count). Mark it with asterisks on a base-3 scale — i.e. **⌊log₃ N⌋ asterisks**:
+  - *N* < 3 → leave blank
+  - 3 ≤ *N* < 9 → `*`
+  - 9 ≤ *N* < 27 → `**`
+  - 27 ≤ *N* < 81 → `***`
+  - …and so on, adding one asterisk at each successive power of 3.
 
 ---
 

--- a/isolde/pyproject.toml.in
+++ b/isolde/pyproject.toml.in
@@ -26,6 +26,16 @@ dependencies = [
     "ChimeraX-Arrays ~=1.0" 
 ]
 
+[project.optional-dependencies]
+# ML-based ligand parameterisation backends.  None of these are required for
+# standard AMBER14/CHARMM36 simulations; install whichever you want to use.
+garnet = [
+    "garnetff",
+    "torch",
+    "torch_geometric",
+    "igraph",
+]
+
 [tool.setuptools.dynamic]
 # Set the version in ISOLDE's top-level __init__.py
 version = { attr = "src.__version__"}

--- a/isolde/src/__init__.py
+++ b/isolde/src/__init__.py
@@ -33,6 +33,15 @@ def register_template_name_attr(session):
     Residue.register_attr(session, 'isolde_template_name',
         'isolde', attr_type=str, can_return_none=True)
 
+def register_amber_type_cache_attrs(session):
+    from chimerax.atomic import Atom, Residue
+    Atom.register_attr(session, 'isolde_amber_type',
+        'isolde', attr_type=str, can_return_none=True)
+    Atom.register_attr(session, 'isolde_amber_params',
+        'isolde', attr_type=str, can_return_none=True)
+    Residue.register_attr(session, 'isolde_amber_cache_key',
+        'isolde', attr_type=str, can_return_none=True)
+
 
 __version__ = "1.13.dev0"
 
@@ -51,6 +60,7 @@ class _MyAPI(BundleAPI):
         register_domain_cluster_attr(session)
         register_model_isolde_init_attr(session)
         register_template_name_attr(session)
+        register_amber_type_cache_attrs(session)
         from . import settings
         settings.basic_settings = settings._IsoldeBasicSettings(session, 'isolde')
         settings.color_settings = settings._IsoldeColorSettings(session, 'isolde')
@@ -58,6 +68,15 @@ class _MyAPI(BundleAPI):
         if session.ui.is_gui:
             from .toolbar import ToolbarButtonMgr
             session._isolde_tb = ToolbarButtonMgr(session)
+            # Register the ISOLDE settings page. On a cold start the main window
+            # doesn't exist yet (it's built after bundle initialisation), so defer
+            # to the UI 'ready' trigger; if ISOLDE is (re)installed into an already-
+            # running session that trigger has already fired, so register now.
+            if session.ui.main_window is not None:
+                settings.register_settings_options(session)
+            else:
+                session.ui.triggers.add_handler('ready', lambda *args, ses=session:
+                    settings.register_settings_options(ses))
 
     @staticmethod
     def get_class(class_name):

--- a/isolde/src/constants.py
+++ b/isolde/src/constants.py
@@ -150,6 +150,13 @@ class _Defaults:
         'SMOOTHING_ALPHA_MAX':          1.0,
         'SMOOTHING_ALPHA_MIN':          0.01,
 
+        ###
+        # User interface
+        ###
+        # Startup experience level: 0=Default, 1=Advanced, 2=Developer
+        # (matches ExpertModeSelector in ui/ui_base.py)
+        'EXPERIENCE_LEVEL':             0,
+
 
         ###
         # Constants specific to ChimeraX - lengths in Angstroms beyond this point!

--- a/isolde/src/isolde.py
+++ b/isolde/src/isolde.py
@@ -187,7 +187,9 @@ class Isolde():
         sp.triggers.add_handler(sp.PARAMETER_CHANGED, self._sim_param_changed_cb)
 
         from .openmm.forcefields import ForcefieldMgr
-        ffmgr = self._ff_mgr = ForcefieldMgr(self.session)
+        from .openmm.param_provider import make_parameterisation_provider
+        ffmgr = ForcefieldMgr(self.session)
+        self._param_provider = make_parameterisation_provider(ffmgr)
 
         self._status = self.session.logger.status
 
@@ -340,8 +342,14 @@ class Isolde():
         return self.session.ui.is_gui
 
     @property
+    def param_provider(self):
+        '''The active :class:`~chimerax.isolde.openmm.param_provider.ParameterisationProvider`.'''
+        return self._param_provider
+
+    @property
     def forcefield_mgr(self):
-        return self._ff_mgr
+        '''Backward-compat shim: returns the :class:`ForcefieldMgr` inside the provider.'''
+        return self._param_provider.forcefield_mgr
 
 
 
@@ -710,6 +718,8 @@ class Isolde():
     ####
 
     def _set_right_mouse_mode_tug_atom(self, *_):
+        if not self.gui_mode:
+            return
         from chimerax.core.commands import run
         run(self.session, 'ui mousemode right "isolde tug atom"', log=False)
 
@@ -1034,8 +1044,9 @@ class Isolde():
     def _sim_end_cb(self, trigger_name, reason):
         for d in self._haptic_devices:
             d.cleanup()
-        from chimerax.mouse_modes import TranslateMouseMode
-        self.session.ui.mouse_modes.bind_mouse_mode('right', [], TranslateMouseMode(self.session))
+        if self.gui_mode:
+            from chimerax.mouse_modes import TranslateMouseMode
+            self.session.ui.mouse_modes.bind_mouse_mode('right', [], TranslateMouseMode(self.session))
         # Release the oversampling-rate lock taken in _sim_start_cb *before* firing
         # SIMULATION_TERMINATED, so listeners (e.g. the map-settings GUI, which
         # re-enables its oversampling control on that trigger) see the lock already
@@ -1059,8 +1070,9 @@ class Isolde():
             self.session.logger.info('ISOLDE: model deleted during running simulation.')
             return
 
-        from chimerax.core.commands import run
-        run(self.session, f'clipper spot #{self.selected_model.id_string}', log=False)
+        if self.gui_mode:
+            from chimerax.core.commands import run
+            run(self.session, f'clipper spot #{self.selected_model.id_string}', log=False)
         from chimerax.clipper import get_map_mgr
         mmgr = get_map_mgr(m)
         if mmgr is not None:

--- a/isolde/src/openmm/espaloma_charge_provider.py
+++ b/isolde/src/openmm/espaloma_charge_provider.py
@@ -1,0 +1,342 @@
+# @Author: Tristan Croll
+# @Date:   03-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 03-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Hybrid ligand parameterisation: espaloma-charge for partial charges +
+MMFF94 (RDKit) for bonds/angles/torsions + GAFF2-element LJ table.
+
+This is a pip-installable alternative to full espaloma::
+
+    pip install espaloma-charge dgl
+
+No conda or AmberTools required.
+
+- ``espaloma-charge`` (0.0.8+) provides GNN-based partial charges trained to
+  reproduce AM1-BCC quality.
+- All bonded parameters (bonds, angles, torsions) come from MMFF94 via RDKit.
+- LJ parameters use the same GAFF2-element table as ``amber14+mmff`` so that
+  Lorentz-Berthelot mixing with AMBER14 protein atoms is physically consistent.
+
+DGL compatibility
+-----------------
+``espaloma-charge`` pulls in DGL, whose ``graphbolt`` sampling subsystem ships
+version-matched native libraries that do not exist for recent PyTorch builds
+(e.g. DGL 2.2.1 tops out at torch 2.3, but ChimeraX ships torch >= 2.12).  On
+such installs a bare ``import dgl`` dies inside ``graphbolt`` before core DGL
+loads.  :func:`_ensure_dgl_importable` neutralises that at import time so the
+backend works out of the box without hand-patching the DGL install.
+
+The model checkpoint (a pickled ``nn.Module``) is loaded once per session via
+:func:`_load_espaloma_model` with ``weights_only=False`` (PyTorch >= 2.6 defaults
+it to ``True`` and would otherwise refuse the checkpoint), and cached under
+``torch.hub`` rather than the current working directory that stock
+``espaloma_charge.charge`` uses.
+
+Known limitations
+-----------------
+- **Charged ligands are not supported.**  Bond orders are inferred from 3D
+  geometry via ``DetermineBondOrders(mol, charge=0)`` (in
+  :func:`.mmff_provider._cx_residue_to_rdmol`), i.e. the ligand is assumed
+  neutral.  A charged species such as GTP (net -8) fails bond perception with
+  "Final molecular charge does not match input"; the residue then falls back to
+  AMBER14.  This is a safe, expected fallback, not a crash.
+- **Bonded terms are MMFF94, not a self-consistent AMBER/GAFF field.**  Charges
+  are AM1-BCC-quality, but the bonded/VdW terms are an approximation; prefer
+  ``amber14+garnet`` for charge-sensitive production work.
+- **Good smoke-test ligands** (neutral, MMFF94-supported, unambiguous bonds):
+  glycerol (``GOL``), benzene (``BNZ``), ethylene glycol (``EDO``).
+'''
+
+import math
+from .param_provider import LigandBackedParameterisationProvider
+from .mmff_provider import (
+    _cx_residue_to_rdmol,
+    _KCAL_TO_KJ, _ANG_TO_NM, _DEG_TO_RAD, _MDYNE_A_TO_KCAL,
+    _ELEMENT_LJ, _DEFAULT_LJ,
+)
+
+
+_dgl_guarded = False
+
+
+def _ensure_dgl_importable():
+    '''
+    Make ``import dgl`` succeed even when no ``graphbolt`` native library
+    matches the installed PyTorch.
+
+    ``graphbolt`` is DGL's optional GPU sampling subsystem; espaloma-charge
+    uses only core ``DGLGraph``, never graphbolt.  But DGL imports it eagerly
+    (``dgl`` -> ``dataloading`` -> ``distributed`` -> ``dist_graph`` ->
+    ``from .. import graphbolt as gb``), so a missing/incompatible graphbolt
+    build takes the whole package down.
+
+    If a plain ``import dgl`` fails, we register an empty stub module under
+    ``sys.modules['dgl.graphbolt']``.  CPython's ``IMPORT_FROM`` falls back to
+    a ``sys.modules`` lookup when the attribute is absent, so DGL's internal
+    ``from .. import graphbolt`` resolves to the stub and the real (broken)
+    ``graphbolt/__init__.py`` never executes.  Every ``gb.<name>`` reference in
+    DGL's ``distributed`` package lives inside a function body, so nothing at
+    import time needs the stub to be populated.
+
+    Idempotent, and a no-op when DGL imports cleanly (patched install or a
+    future torch-compatible DGL) so working setups are never disturbed.
+    '''
+    global _dgl_guarded
+    if _dgl_guarded:
+        return
+    _dgl_guarded = True
+
+    import sys
+    if 'dgl' in sys.modules:
+        return  # already imported successfully by someone else
+    try:
+        import dgl  # noqa: F401
+        return     # clean import — nothing to do
+    except Exception:
+        # A failed import leaves no partial 'dgl' in sys.modules (CPython
+        # removes it on error), so we can safely stub and let the caller's
+        # own `import espaloma_charge`/`import dgl` retry against the stub.
+        import types
+        sys.modules.setdefault('dgl.graphbolt', types.ModuleType('dgl.graphbolt'))
+
+
+def _esc_system_to_ffxml(residue, mol, charges) -> str:
+    '''
+    Build a ForceField XML template using the supplied *charges*, MMFF94
+    bonds/angles/torsions, and the GAFF2-element LJ table.
+
+    Atom type prefix is ``ESC_`` to prevent clashes with the ``MMF_`` types
+    that ``amber14+mmff`` registers separately.
+    '''
+    import xml.etree.ElementTree as ET
+    from rdkit.Chem import rdForceFieldHelpers
+
+    cx_atoms  = list(residue.atoms)
+    n_atoms   = mol.GetNumAtoms()
+    rname     = residue.name
+    type_names = [f'ESC_{rname}_{i}' for i in range(n_atoms)]
+
+    props = rdForceFieldHelpers.MMFFGetMoleculeProperties(mol, mmffVariant='MMFF94')
+    if props is None:
+        raise RuntimeError(
+            f'MMFF94 could not assign bond/angle parameters for residue {rname!r}')
+
+    def _lj(i):
+        return _ELEMENT_LJ.get(mol.GetAtomWithIdx(i).GetAtomicNum(), _DEFAULT_LJ)
+
+    sigma   = [_lj(i)[0] for i in range(n_atoms)]
+    epsilon = [_lj(i)[1] for i in range(n_atoms)]
+
+    root = ET.Element('ForceField')
+
+    at_el = ET.SubElement(root, 'AtomTypes')
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(at_el, 'Type', {
+            'name':    type_names[i],
+            'class':   type_names[i],
+            'element': cx_a.element.name.capitalize(),
+            'mass':    str(cx_a.element.mass),
+        })
+
+    res_el = ET.SubElement(ET.SubElement(root, 'Residues'), 'Residue', name=rname)
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(res_el, 'Atom',
+            name=cx_a.name, type=type_names[i], charge=str(charges[i]))
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1_name, a2_name in zip(a1_col.names, a2_col.names):
+        ET.SubElement(res_el, 'Bond', atomName1=a1_name, atomName2=a2_name)
+
+    nb_el = ET.SubElement(root, 'NonbondedForce',
+        coulomb14scale='0.8333333333333333', lj14scale='0.5')
+    ET.SubElement(nb_el, 'UseAttributeFromResidue', name='charge')
+    for i in range(n_atoms):
+        ET.SubElement(nb_el, 'Atom',
+            type=type_names[i], sigma=str(sigma[i]), epsilon=str(epsilon[i]))
+
+    # HarmonicBondForce — MMFF94 bond stretches
+    # GetMMFFBondStretchParams -> (bondType, kb, r0); kb in md/Å, r0 in Å.
+    bf_el = None
+    for bond in mol.GetBonds():
+        i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+        bp = props.GetMMFFBondStretchParams(mol, i, j)
+        if bp is None:
+            continue
+        kb, r0 = bp[1], bp[2]
+        k_kJ_nm2 = kb * _MDYNE_A_TO_KCAL * _KCAL_TO_KJ / (_ANG_TO_NM ** 2)
+        r0_nm    = r0 * _ANG_TO_NM
+        if bf_el is None:
+            bf_el = ET.SubElement(root, 'HarmonicBondForce')
+        ET.SubElement(bf_el, 'Bond',
+            type1=type_names[i], type2=type_names[j],
+            length=str(r0_nm), k=str(k_kJ_nm2))
+
+    # HarmonicAngleForce — MMFF94 angle bends
+    # GetMMFFAngleBendParams -> (angleType, ka, theta0); ka in md·Å/rad², deg.
+    af_el = None
+    for j in range(n_atoms):
+        nbrs = [b.GetOtherAtomIdx(j) for b in mol.GetAtomWithIdx(j).GetBonds()]
+        for ia in range(len(nbrs)):
+            i = nbrs[ia]
+            for ib in range(ia + 1, len(nbrs)):
+                k = nbrs[ib]
+                ap = props.GetMMFFAngleBendParams(mol, i, j, k)
+                if ap is None:
+                    continue
+                ka, theta0 = ap[1], ap[2]
+                ka_kJ   = ka * _MDYNE_A_TO_KCAL * _KCAL_TO_KJ
+                th0_rad = theta0 * _DEG_TO_RAD
+                if af_el is None:
+                    af_el = ET.SubElement(root, 'HarmonicAngleForce')
+                ET.SubElement(af_el, 'Angle',
+                    type1=type_names[i], type2=type_names[j], type3=type_names[k],
+                    angle=str(th0_rad), k=str(ka_kJ))
+
+    # PeriodicTorsionForce — MMFF94 proper torsions
+    # MMFF94: E = (V1/2)*(1+cos φ) + (V2/2)*(1−cos 2φ) + (V3/2)*(1+cos 3φ)
+    # Mapped to OpenMM k*(1+cos(nφ−phase)):
+    #   V1 → k=|V1|/2, n=1, phase=0   (sign flip → phase += π)
+    #   V2 → k=|V2|/2, n=2, phase=π
+    #   V3 → k=|V3|/2, n=3, phase=0
+    tf_el = None
+    seen_torsions = set()
+    for bond_jk in mol.GetBonds():
+        j = bond_jk.GetBeginAtomIdx()
+        k = bond_jk.GetEndAtomIdx()
+        i_list = [b.GetOtherAtomIdx(j) for b in mol.GetAtomWithIdx(j).GetBonds()
+                  if b.GetOtherAtomIdx(j) != k]
+        l_list = [b.GetOtherAtomIdx(k) for b in mol.GetAtomWithIdx(k).GetBonds()
+                  if b.GetOtherAtomIdx(k) != j]
+        for i in i_list:
+            for l in l_list:
+                if l == i:
+                    continue
+                tkey = tuple(sorted([i, j, k, l]) + [j, k])
+                if tkey in seen_torsions:
+                    continue
+                seen_torsions.add(tkey)
+                tp = props.GetMMFFTorsionParams(mol, i, j, k, l)
+                if tp is None:
+                    continue
+                # GetMMFFTorsionParams -> (torsionType, V1, V2, V3); V in kcal/mol.
+                v1, v2, v3 = tp[1], tp[2], tp[3]
+                if tf_el is None:
+                    tf_el = ET.SubElement(root, 'PeriodicTorsionForce')
+                for v, n_per, base_phase in ((v1, 1, 0.0), (v2, 2, math.pi), (v3, 3, 0.0)):
+                    if abs(v) < 1e-6:
+                        continue
+                    k_kJ  = abs(v) * _KCAL_TO_KJ / 2.0
+                    phase = base_phase + (math.pi if v < 0.0 else 0.0)
+                    ET.SubElement(tf_el, 'Proper',
+                        type1=type_names[i], type2=type_names[j],
+                        type3=type_names[k], type4=type_names[l],
+                        periodicity1=str(n_per),
+                        phase1=str(phase),
+                        k1=str(k_kJ))
+
+    return ET.tostring(root, encoding='unicode')
+
+
+# In-memory cache of the loaded GNN, shared across all residues in a session.
+_ESPALOMA_MODEL = None
+
+
+def _load_espaloma_model():
+    '''
+    Load (and cache) the espaloma-charge GNN.
+
+    This reimplements the model-loading half of ``espaloma_charge.app.charge``
+    to fix two shortcomings of the stock function for in-session use:
+
+    - The stock ``charge()`` downloads/reads ``model.pt`` from a *relative*
+      path in the current working directory, which is unpredictable inside a
+      ChimeraX session.  We cache it under ``torch.hub`` instead — a stable,
+      always-writable per-user location.
+    - The stock ``charge()`` reloads the model from disk on every call; since
+      ISOLDE parameterises one residue at a time, that would re-deserialise the
+      GNN for every ligand.  We load it once and keep it in memory.
+
+    PyTorch >= 2.6 defaults ``torch.load`` to ``weights_only=True`` and refuses
+    to unpickle the published ``model.pt`` (a full ``nn.Module``, not a
+    state-dict).  The model is from choderalab's trusted release, so
+    ``weights_only=False`` is appropriate here.
+    '''
+    global _ESPALOMA_MODEL
+    if _ESPALOMA_MODEL is not None:
+        return _ESPALOMA_MODEL
+
+    import os
+    import torch
+    from urllib import request
+    _ensure_dgl_importable()
+    from espaloma_charge.app import MODEL_URL
+
+    cache_dir = os.path.join(torch.hub.get_dir(), 'espaloma_charge')
+    os.makedirs(cache_dir, exist_ok=True)
+    model_path = os.path.join(cache_dir, 'model.pt')
+    if not os.path.exists(model_path):
+        request.urlretrieve(MODEL_URL.strip(), model_path)
+
+    _ESPALOMA_MODEL = torch.load(model_path, weights_only=False)
+    return _ESPALOMA_MODEL
+
+
+def _espaloma_charges(mol):
+    '''
+    Run the espaloma-charge GNN on *mol* and return an ``(n_atoms,)`` numpy
+    array of partial charges.  Mirrors ``espaloma_charge.app.charge`` but uses
+    the cached model from :func:`_load_espaloma_model`.
+    '''
+    _ensure_dgl_importable()
+    from espaloma_charge.utils import from_rdkit_mol
+
+    model = _load_espaloma_model()
+    graph = from_rdkit_mol(mol)
+    graph = model(graph)
+    return graph.ndata['q'].cpu().detach().flatten().numpy()
+
+
+def _espaloma_charge_parameterise_residue(residue, logger) -> str:
+    '''
+    Build the RDKit mol, obtain GNN partial charges via espaloma-charge,
+    then assemble the ForceField XML using MMFF94 bonded parameters.
+    '''
+    from rdkit.Chem import AllChem
+
+    mol = _cx_residue_to_rdmol(residue)
+    result = AllChem.MMFFOptimizeMolecule(mol, maxIters=200)
+    if result == -1:
+        raise RuntimeError(
+            f'MMFF94 setup failed for {residue.name!r} (needed for bonded terms). '
+            f'The molecule may contain elements or bonding patterns not supported '
+            f'by MMFF94.')
+
+    charges = _espaloma_charges(mol).tolist()
+    return _esc_system_to_ffxml(residue, mol, charges)
+
+
+class EspalomaChargeParameterisationProvider(LigandBackedParameterisationProvider):
+    '''
+    Parameterisation provider using AMBER14 for standard residues and a
+    espaloma-charge / MMFF94 hybrid for ligands.
+
+    - Partial charges: espaloma-charge GNN (AM1-BCC quality, pip-installable)
+    - Bonded terms:    MMFF94 via RDKit (already bundled with ChimeraX)
+    - LJ parameters:  GAFF2-element table, compatible with AMBER14 mixing
+
+    Install the extra dependency with::
+
+        pip install espaloma-charge dgl
+    '''
+
+    @property
+    def backend_forcefield_key(self):
+        return 'amber14+espaloma-charge'
+
+    def _parameterise_one(self, residue, logger):
+        xml = _espaloma_charge_parameterise_residue(residue, logger)
+        return xml, {}

--- a/isolde/src/openmm/espaloma_provider.py
+++ b/isolde/src/openmm/espaloma_provider.py
@@ -1,0 +1,206 @@
+# @Author: Tristan Croll
+# @Date:   02-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 02-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+
+from .param_provider import LigandBackedParameterisationProvider
+
+
+def _cx_residue_to_offmol(residue):
+    '''
+    Convert a ChimeraX residue to an OpenFF Molecule.
+
+    Builds an RDKit RWMol from atom elements and 3D coordinates, uses
+    rdDetermineBonds to infer bond orders from geometry, then converts to
+    an OpenFF Molecule via ``from_rdkit``.
+
+    Requires the residue to have explicit hydrogen atoms for reliable bond-order
+    inference.  ``charge=0`` is assumed; charged ligands may fail and will fall
+    back to AMBER14.
+    '''
+    from rdkit import Chem
+    from rdkit.Chem import AllChem, rdDetermineBonds
+    from openff.toolkit import Molecule as OFFMolecule
+
+    cx_atoms = list(residue.atoms)
+    atom_index = {a: i for i, a in enumerate(cx_atoms)}
+    n = len(cx_atoms)
+
+    mol = Chem.RWMol()
+    conf = Chem.Conformer(n)
+    for i, a in enumerate(cx_atoms):
+        mol.AddAtom(Chem.Atom(a.element.number))
+        coord = a.coord  # Angstrom
+        conf.SetAtomPosition(i, (float(coord[0]), float(coord[1]), float(coord[2])))
+    mol.AddConformer(conf, assignId=True)
+
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1, a2 in zip(a1_col, a2_col):
+        mol.AddBond(atom_index[a1], atom_index[a2], Chem.BondType.SINGLE)
+
+    rdDetermineBonds.DetermineBondOrders(mol, charge=0)
+    mol_ro = mol.GetMol()
+    AllChem.AssignStereochemistryFrom3D(mol_ro)
+
+    return OFFMolecule.from_rdkit(mol_ro, allow_undefined_stereo=True)
+
+
+def _build_single_residue_omm_topology(residue):
+    '''
+    Build an OpenMM Topology for a single ChimeraX residue.
+    Atom order matches ``list(residue.atoms)``.
+    '''
+    from openmm.app import Topology as OMMTop, Element as OMMElement
+
+    cx_atoms = list(residue.atoms)
+    atom_index = {a: i for i, a in enumerate(cx_atoms)}
+
+    top = OMMTop()
+    chain = top.addChain()
+    omm_res = top.addResidue(residue.name, chain)
+    omm_atoms = []
+    for a in cx_atoms:
+        elem = OMMElement.getByAtomicNumber(a.element.number)
+        omm_atoms.append(top.addAtom(a.name, elem, omm_res))
+
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1, a2 in zip(a1_col, a2_col):
+        top.addBond(omm_atoms[atom_index[a1]], omm_atoms[atom_index[a2]])
+
+    return top
+
+
+def _espaloma_system_to_ffxml(residue, system) -> str:
+    '''
+    Convert an Espaloma-produced OpenMM System to a ForceField XML template
+    string suitable for
+    ``ForceField.loadFile(io.StringIO(xml), resname_prefix='USER_')``.
+
+    Unlike GARNET, Espaloma stores charges, sigma, and epsilon all in
+    NonbondedForce — there is no CustomNonbondedForce to extract VdW from, so
+    standard Lorentz-Berthelot mixing with AMBER14 protein atoms applies.
+    '''
+    import xml.etree.ElementTree as ET
+    from openmm import unit as omm_unit
+    from openmm.openmm import (HarmonicBondForce, HarmonicAngleForce,
+                               PeriodicTorsionForce, NonbondedForce)
+
+    cx_atoms = list(residue.atoms)
+    n_atoms = system.getNumParticles()
+    rname = residue.name
+    type_names = [f'ESP_{rname}_{i}' for i in range(n_atoms)]
+
+    charges = [0.0] * n_atoms
+    sigma   = [0.35] * n_atoms
+    epsilon = [0.40] * n_atoms
+
+    for force in system.getForces():
+        if isinstance(force, NonbondedForce):
+            for ni in range(force.getNumParticles()):
+                q, sig, eps = force.getParticleParameters(ni)
+                charges[ni] = q.value_in_unit(omm_unit.elementary_charge)
+                sigma[ni]   = sig.value_in_unit(omm_unit.nanometer)
+                epsilon[ni] = eps.value_in_unit(omm_unit.kilojoule_per_mole)
+            break
+
+    root = ET.Element('ForceField')
+
+    at_el = ET.SubElement(root, 'AtomTypes')
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(at_el, 'Type', {
+            'name':    type_names[i],
+            'class':   type_names[i],
+            'element': cx_a.element.name.capitalize(),
+            'mass':    str(cx_a.element.mass),
+        })
+
+    res_el = ET.SubElement(ET.SubElement(root, 'Residues'), 'Residue', name=rname)
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(res_el, 'Atom',
+            name=cx_a.name,
+            type=type_names[i],
+            charge=str(charges[i]))
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1_name, a2_name in zip(a1_col.names, a2_col.names):
+        ET.SubElement(res_el, 'Bond', atomName1=a1_name, atomName2=a2_name)
+
+    nb_el = ET.SubElement(root, 'NonbondedForce',
+        coulomb14scale='0.8333333333333333', lj14scale='0.5')
+    ET.SubElement(nb_el, 'UseAttributeFromResidue', name='charge')
+    for i in range(n_atoms):
+        ET.SubElement(nb_el, 'Atom',
+            type=type_names[i],
+            sigma=str(sigma[i]),
+            epsilon=str(epsilon[i]))
+
+    for force in system.getForces():
+        if isinstance(force, HarmonicBondForce):
+            bf_el = ET.SubElement(root, 'HarmonicBondForce')
+            for bi in range(force.getNumBonds()):
+                i1, i2, r0, k = force.getBondParameters(bi)
+                ET.SubElement(bf_el, 'Bond',
+                    type1=type_names[i1], type2=type_names[i2],
+                    length=str(r0.value_in_unit(omm_unit.nanometer)),
+                    k=str(k.value_in_unit(
+                        omm_unit.kilojoule_per_mole / omm_unit.nanometer**2)))
+
+        elif isinstance(force, HarmonicAngleForce):
+            af_el = ET.SubElement(root, 'HarmonicAngleForce')
+            for ai in range(force.getNumAngles()):
+                i1, i2, i3, theta0, k = force.getAngleParameters(ai)
+                ET.SubElement(af_el, 'Angle',
+                    type1=type_names[i1], type2=type_names[i2],
+                    type3=type_names[i3],
+                    angle=str(theta0.value_in_unit(omm_unit.radian)),
+                    k=str(k.value_in_unit(
+                        omm_unit.kilojoule_per_mole / omm_unit.radian**2)))
+
+        elif isinstance(force, PeriodicTorsionForce):
+            tf_el = ET.SubElement(root, 'PeriodicTorsionForce')
+            for ti in range(force.getNumTorsions()):
+                i1, i2, i3, i4, per, phase, k = force.getTorsionParameters(ti)
+                ET.SubElement(tf_el, 'Proper',
+                    type1=type_names[i1], type2=type_names[i2],
+                    type3=type_names[i3], type4=type_names[i4],
+                    periodicity1=str(per),
+                    phase1=str(phase.value_in_unit(omm_unit.radian)),
+                    k1=str(k.value_in_unit(omm_unit.kilojoule_per_mole)))
+
+    return ET.tostring(root, encoding='unicode')
+
+
+def _espaloma_parameterise_residue(residue, logger) -> str:
+    '''Orchestrate the full Espaloma parameterisation pipeline for one residue.'''
+    import espaloma as esp
+    from openmm.app import NoCutoff
+
+    off_mol = _cx_residue_to_offmol(residue)
+    omm_top = _build_single_residue_omm_topology(residue)
+    ff = esp.get_forcefield('espaloma-0.3.2')
+    system = ff.createSystem(omm_top, molecules=[off_mol], nonbondedMethod=NoCutoff)
+    return _espaloma_system_to_ffxml(residue, system)
+
+
+class EspalomaParameterisationProvider(LigandBackedParameterisationProvider):
+    '''
+    Parameterisation provider using AMBER14 for standard residues and
+    Espaloma for ligands.
+
+    When ``sim_params.forcefield`` is ``'amber14+espaloma'``, intercepts
+    unparameterised non-polymer residues and runs them through the Espaloma
+    GNN force field via the OpenFF Toolkit.
+    '''
+
+    @property
+    def backend_forcefield_key(self):
+        return 'amber14+espaloma'
+
+    def _parameterise_one(self, residue, logger):
+        xml = _espaloma_parameterise_residue(residue, logger)
+        return xml, {}

--- a/isolde/src/openmm/forcefields.py
+++ b/isolde/src/openmm/forcefields.py
@@ -83,7 +83,13 @@ class ForcefieldMgr:
         for f in glob.glob(os.path.join(ff_dir, '*.pickle')):
             os.remove(f)
 
+    @staticmethod
+    def _base_ff_key(key):
+        '''Strip any "+backend" suffix (e.g. "amber14+garnet" → "amber14").'''
+        return key.split('+')[0]
+
     def __getitem__(self, key):
+        key = self._base_ff_key(key)
         ffd = self._ff_dict
         if key in ffd.keys():
             return ffd[key]
@@ -98,6 +104,7 @@ class ForcefieldMgr:
             return self.load_ff(key)
 
     def ligand_db(self, key):
+        key = self._base_ff_key(key)
         db = self._ligand_dict.get(key, None)
         if db is None:
             ligand_zip = _ligand_files[key]
@@ -165,7 +172,7 @@ class ForcefieldMgr:
 from openmm.app import ForceField as _ForceField
 class ForceField(_ForceField):
     def assignTemplates(self, topology, ignoreExternalBonds=False,
-            explicit_templates={}):
+            explicit_templates={}, residues=None):
         '''
         Parameters
         ----------
@@ -178,6 +185,9 @@ class ForceField(_ForceField):
         explicit_templates: dict={}
             An optional {residue: template_name} dict specifying the templates to
             use for particular residues
+        residues: iterable of openmm `Residue`, optional
+            If given, restrict matching to just these topology residues (e.g. a
+            cache-miss subset) rather than every residue in the topology.
 
 
         Returns three items:
@@ -198,7 +208,7 @@ class ForceField(_ForceField):
         unmatched = []
 
         templateSignatures = self._templateSignatures
-        for res in topology.residues():
+        for res in (residues if residues is not None else topology.residues()):
             sig = _createResidueSignature([atom.element for atom in res.atoms()])
             explicit = explicit_templates.get(res, None)
             if explicit:
@@ -237,6 +247,10 @@ class ForceField(_ForceField):
             template.graph = self.template_graph(template)
         else:
             template.graph = None
+        # Bumped on every template registration (including runtime loadFile()
+        # calls) so cached per-atom AMBER types can detect when a new template
+        # might change matching for residues that were previously unambiguous.
+        self._isolde_template_generation = getattr(self, '_isolde_template_generation', 0) + 1
 
     @staticmethod
     def residue_graph(residue):

--- a/isolde/src/openmm/garnet_provider.py
+++ b/isolde/src/openmm/garnet_provider.py
@@ -1,0 +1,698 @@
+# @Author: Tristan Croll
+# @Date:   01-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 01-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+GARNET-backed parameterisation provider.
+
+:class:`GarnetParameterisationProvider` extends
+:class:`ForceFieldParameterisationProvider`.  When ``sim_params.forcefield``
+is ``'amber14+garnet'`` it intercepts :class:`UnparameterisedResiduesError`,
+runs GARNET inference on the unmatched ligand residues, registers the resulting
+XML templates under the ``USER_`` prefix, and retries the system build.
+
+For any other forcefield value the class delegates transparently to the parent,
+so installing this provider changes nothing for the pure AMBER14/CHARMM36 paths.
+
+GARNET (Greener Group, MRC LMB, 2026) is a graph-neural-network forcefield
+trained on quantum mechanical, condensed-phase and NMR data.  The model weights
+are bundled with the ``garnetff`` package; no separate download is required.
+
+Paper: arXiv:2603.16770 — "Training a force field for proteins and small
+molecules from scratch" (Blanco-Gonzalez et al., 2026)
+
+Dependencies (install once inside ChimeraX):
+    pip install garnetff torch torch_geometric igraph
+
+No openff.toolkit or RDKit is required — a self-contained shim topology is
+built directly from ChimeraX atom/bond data.
+
+VdW strategy
+------------
+GARNET uses a double-exponential (DE) potential internally.  This provider
+applies a three-tier VdW strategy that preserves GARNET's native DE physics for
+ligand–ligand interactions while keeping protein–ligand cross-terms as standard
+Lennard-Jones:
+
+* **Ligand–ligand:** DE — GARNET's native ``CustomNonbondedForce``, restricted
+  to the GARNET-atom set via ``addInteractionGroup``.
+* **Protein–ligand cross-terms:** LJ — Lorentz-Berthelot mixing using GARNET's
+  sigma/epsilon values in AMBER14's ``NonbondedForce``.  This is an
+  approximation; an exact DE cross-term requires protein DE parameters.
+* **Protein–protein:** LJ — AMBER14, unchanged.
+
+Implementation note: AMBER14's ``NonbondedForce`` already computes LJ for
+ligand–ligand pairs as a side-effect.  A second ``CustomNonbondedForce``
+(``_lj_correction``) restricted to the same ligand set subtracts that LJ, so
+the net ligand–ligand VdW is DE.  This double-force pattern makes the future
+"DE everywhere" upgrade straightforward: extend both the DE force and the
+correction to all atoms, replace AMBER14 types with DE types, and delete the
+correction once the cross-terms are also DE.
+
+1-4 intra-ligand VdW remains as AMBER-style 0.5 × LJ in the ``NonbondedForce``
+exceptions (the two custom forces exclude those pairs).  This is a known
+approximation accepted for model building.
+'''
+
+from .param_provider import LigandBackedParameterisationProvider
+
+# Atomic numbers supported by GARNET and their internal index/name (from garnetff source).
+_ELEMENT_INDICES = {
+    1: 0, 3: 1,  5: 2,  6: 3,  7: 4,  8: 5,  9: 6,
+    11: 7, 12: 8, 14: 9, 15: 10, 16: 11,
+    17: 12, 19: 13, 20: 14, 35: 15, 53: 16,
+}
+_ELEMENT_NAMES = [
+    'H', 'Li', 'B', 'C', 'N', 'O', 'F',
+    'Na', 'Mg', 'Si', 'P', 'S', 'Cl', 'K', 'Ca', 'Br', 'I',
+]
+
+
+# ---------------------------------------------------------------------------
+# Shim topology classes
+# Expose the interface expected by garnetff without requiring openff.toolkit.
+# ---------------------------------------------------------------------------
+
+class _GarnetFormalCharge:
+    '''
+    Minimal formal-charge quantity-like object.
+
+    ``fc / fc.units`` and ``fc / fc.u`` both return the integer charge value,
+    matching the two call sites inside garnetff source:
+      - ``topology_to_data``:       ``int(a.formal_charge / a.formal_charge.units)``
+      - ``find_identical_atoms``:   ``fci / fci.u``
+    '''
+    def __init__(self, value: int):
+        self._v = int(value)
+        self.units = 1
+        self.u = 1
+
+    def __truediv__(self, other):
+        return self._v
+
+
+class _AtomRef:
+    '''Minimal atom reference used in angle/torsion index tuples.'''
+    __slots__ = ('molecule_atom_index',)
+
+    def __init__(self, idx: int):
+        self.molecule_atom_index = idx
+
+
+def _infer_formal_charge(cx_atom) -> int:
+    '''Best-effort formal charge from IDATM type; 0 for the vast majority of atoms.'''
+    t = cx_atom.idatm_type
+    if t in ('N3+', 'N2+', 'O1+', 'Oar+'):
+        return 1
+    if t in ('O2-', 'S3-'):
+        return -1
+    return 0
+
+
+def _garnet_element_name(atomic_number: int) -> str:
+    idx = _ELEMENT_INDICES.get(atomic_number)
+    if idx is None:
+        raise ValueError(
+            f'Atomic number {atomic_number} is not supported by GARNET. '
+            'Supported elements: H Li B C N O F Na Mg Si P S Cl K Ca Br I.')
+    return _ELEMENT_NAMES[idx]
+
+
+def _compute_garnet_atom_names(cx_atoms) -> list:
+    '''
+    Generate GARNET-style element-count atom names in the same order as
+    ``garnetff.data_to_xml`` would produce (C1, N1, O1, C2, …).
+    '''
+    counts = {}
+    names = []
+    for a in cx_atoms:
+        el = _garnet_element_name(a.element.number)
+        c = counts.get(el, 0) + 1
+        counts[el] = c
+        names.append(f'{el}{c}')
+    return names
+
+
+class _GarnetAtom:
+    '''Wraps a ChimeraX atom to satisfy garnetff's atom interface.'''
+
+    def __init__(self, cx_atom, idx: int):
+        self._cx = cx_atom
+        self._idx = idx
+        self._fc = _GarnetFormalCharge(_infer_formal_charge(cx_atom))
+        # Mutable dict — topology_to_openmm_system may overwrite residue_name for polymers.
+        self.metadata = {
+            'residue_name':   cx_atom.residue.name,
+            'residue_number': cx_atom.residue.number,
+            'insertion_code': cx_atom.residue.insertion_code or ' ',
+        }
+
+    @property
+    def atomic_number(self) -> int:
+        return self._cx.element.number
+
+    @property
+    def formal_charge(self) -> _GarnetFormalCharge:
+        return self._fc
+
+    @property
+    def is_aromatic(self) -> bool:
+        return self._cx.idatm_type in ('Car', 'Nar', 'Oar', 'Oar+', 'Sar')
+
+    @property
+    def bonded_atoms(self):
+        '''Bonded atoms within the same residue (intra-residue neighbours).'''
+        r = self._cx.residue
+        return [nb for nb in self._cx.neighbors if nb.residue is r]
+
+
+class _GarnetBond:
+    __slots__ = ('atom1_index', 'atom2_index')
+
+    def __init__(self, i: int, j: int):
+        self.atom1_index = i
+        self.atom2_index = j
+
+
+class _GarnetMolecule:
+    '''
+    Shim molecule built from a single ChimeraX residue.
+
+    Provides: n_atoms, atoms, bonds, angles, propers, amber_impropers,
+    to_networkx(), to_smiles(), is_isomorphic_with().
+    '''
+
+    def __init__(self, residue):
+        self._residue = residue
+        cx_atoms = list(residue.atoms)
+        self._cx_atoms = cx_atoms
+        self._atoms = [_GarnetAtom(a, i) for i, a in enumerate(cx_atoms)]
+        _id = {id(a): i for i, a in enumerate(cx_atoms)}
+
+        # --- bonds (intra-residue) ---
+        bonds = []
+        seen_b = set()
+        for a in cx_atoms:
+            for nb in a.neighbors:
+                if nb.residue is residue:
+                    i, j = _id[id(a)], _id[id(nb)]
+                    key = (min(i, j), max(i, j))
+                    if key not in seen_b:
+                        seen_b.add(key)
+                        bonds.append(_GarnetBond(i, j))
+        self._bonds = bonds
+
+        # --- angles (all i–j–k paths through each central atom j) ---
+        angles = []
+        seen_a = set()
+        for j_idx, j_cx in enumerate(cx_atoms):
+            nbrs = [_id[id(nb)] for nb in j_cx.neighbors if nb.residue is residue]
+            for ii in range(len(nbrs)):
+                for ki in range(ii + 1, len(nbrs)):
+                    i_idx, k_idx = nbrs[ii], nbrs[ki]
+                    key = (min(i_idx, k_idx), j_idx, max(i_idx, k_idx))
+                    if key not in seen_a:
+                        seen_a.add(key)
+                        angles.append([_AtomRef(i_idx), _AtomRef(j_idx), _AtomRef(k_idx)])
+        self._angles = angles
+
+        # --- propers (i–j–k–l paths across each bond j–k) ---
+        propers = []
+        seen_p = set()
+        for b in bonds:
+            j_idx, k_idx = b.atom1_index, b.atom2_index
+            j_nbrs = [_id[id(nb)] for nb in cx_atoms[j_idx].neighbors
+                      if nb.residue is residue and _id[id(nb)] != k_idx]
+            k_nbrs = [_id[id(nb)] for nb in cx_atoms[k_idx].neighbors
+                      if nb.residue is residue and _id[id(nb)] != j_idx]
+            for i_idx in j_nbrs:
+                for l_idx in k_nbrs:
+                    if i_idx == l_idx:
+                        continue
+                    raw = (i_idx, j_idx, k_idx, l_idx)
+                    key = min(raw, raw[::-1])
+                    if key not in seen_p:
+                        seen_p.add(key)
+                        propers.append([_AtomRef(i_idx), _AtomRef(j_idx),
+                                        _AtomRef(k_idx), _AtomRef(l_idx)])
+        self._propers = propers
+
+        # --- AMBER impropers (all combinations of 3 neighbours for each atom) ---
+        from itertools import combinations
+        impropers = []
+        for j_idx, j_cx in enumerate(cx_atoms):
+            nbrs = sorted(_id[id(nb)] for nb in j_cx.neighbors if nb.residue is residue)
+            for i_idx, k_idx, l_idx in combinations(nbrs, 3):
+                impropers.append([_AtomRef(j_idx), _AtomRef(i_idx),
+                                   _AtomRef(k_idx), _AtomRef(l_idx)])
+        self._impropers = impropers
+
+    # ---- GARNET interface ----
+
+    @property
+    def n_atoms(self) -> int:
+        return len(self._atoms)
+
+    @property
+    def atoms(self):
+        return self._atoms
+
+    @property
+    def bonds(self):
+        return self._bonds
+
+    @property
+    def angles(self):
+        return self._angles
+
+    @property
+    def propers(self):
+        return self._propers
+
+    @property
+    def amber_impropers(self):
+        return self._impropers
+
+    def to_networkx(self):
+        import networkx as nx
+        g = nx.Graph()
+        for i, a in enumerate(self._atoms):
+            g.add_node(i, atomic_number=a.atomic_number, formal_charge=a.formal_charge)
+        for b in self._bonds:
+            g.add_edge(b.atom1_index, b.atom2_index)
+        return g
+
+    def to_smiles(self) -> str:
+        # Only used by garnetff to check for "." (multi-component molecule guard).
+        # Residue names never contain ".".
+        return self._residue.name
+
+    def is_isomorphic_with(self, other) -> bool:
+        # With a single-molecule topology this is never called (loop range is empty).
+        return self is other
+
+
+class _GarnetTopology:
+    '''Single-molecule topology shim backed by a ChimeraX residue.'''
+
+    def __init__(self, residue):
+        self._mol = _GarnetMolecule(residue)
+
+    @property
+    def n_atoms(self) -> int:
+        return self._mol.n_atoms
+
+    @property
+    def n_molecules(self) -> int:
+        return 1
+
+    @property
+    def molecules(self):
+        return [self._mol]
+
+    @property
+    def box_vectors(self):
+        return None
+
+    def to_openmm(self):
+        '''
+        Build an OpenMM Topology with GARNET-style element-count atom names
+        (C1, N1, O1, C2, …) — these must match the names in the GARNET-
+        generated ForceField XML that ``createSystem`` will be called with.
+        '''
+        from openmm.app import Topology as OMMTopology, Element as OMMElement
+        top = OMMTopology()
+        chain = top.addChain()
+        res = top.addResidue(self._mol._residue.name, chain)
+        garnet_names = _compute_garnet_atom_names(self._mol._cx_atoms)
+        omm_atoms = []
+        for ga, gname in zip(self._mol._atoms, garnet_names):
+            elem = OMMElement.getByAtomicNumber(ga.atomic_number)
+            omm_atoms.append(top.addAtom(gname, elem, res))
+        for b in self._mol._bonds:
+            top.addBond(omm_atoms[b.atom1_index], omm_atoms[b.atom2_index])
+        return top
+
+
+# ---------------------------------------------------------------------------
+# System → FFXML conversion
+# ---------------------------------------------------------------------------
+
+def _garnet_system_to_ffxml(residue, system) -> str:
+    '''
+    Convert a GARNET-produced OpenMM System to a ForceField XML template
+    string suitable for
+    ``ForceField.loadFile(io.StringIO(xml), resname_prefix='USER_')``.
+
+    Atom indices in *system* correspond to ``list(residue.atoms)`` order
+    (guaranteed by :class:`_GarnetTopology` construction).
+
+    Charge/LJ strategy
+    ------------------
+    GARNET stores partial charges via ``<UseAttributeFromResidue name="charge"/>``
+    in its NonbondedForce and uses a CustomNonbondedForce for VdW.  After
+    ``createSystem()`` the NonbondedForce carries per-particle charges with
+    sigma=1/epsilon=0, and the CustomNonbondedForce carries the real sigma/epsilon.
+
+    This function reads charges from NonbondedForce and sigma/epsilon from
+    CustomNonbondedForce, then writes a single AMBER14-compatible NonbondedForce
+    entry combining all three — allowing correct Lorentz-Berthelot mixing with
+    protein atoms parameterised by AMBER14.
+    '''
+    import xml.etree.ElementTree as ET
+    from openmm import unit as omm_unit
+    from openmm.openmm import (HarmonicBondForce, HarmonicAngleForce,
+                               PeriodicTorsionForce, NonbondedForce,
+                               CustomNonbondedForce)
+
+    cx_atoms = list(residue.atoms)
+    n_atoms = system.getNumParticles()
+    rname = residue.name
+    type_names = [f'GRN_{rname}_{i}' for i in range(n_atoms)]
+
+    # --- extract non-bonded parameters ---
+    charges = [0.0] * n_atoms
+    sigma = [0.35] * n_atoms    # fallback: generic sigma in nm
+    epsilon = [0.40] * n_atoms  # fallback: generic epsilon in kJ/mol
+
+    for force in system.getForces():
+        if isinstance(force, NonbondedForce):
+            for ni in range(force.getNumParticles()):
+                q, _sig, _eps = force.getParticleParameters(ni)
+                charges[ni] = q.value_in_unit(omm_unit.elementary_charge)
+        elif isinstance(force, CustomNonbondedForce):
+            for ni in range(force.getNumParticles()):
+                params = force.getParticleParameters(ni)
+                # GARNET's CustomNonbondedForce defines PerParticleParameters
+                # "sigma" and "epsilon" in that order (nm, kJ/mol).
+                if len(params) >= 2:
+                    sigma[ni] = float(params[0])
+                    epsilon[ni] = float(params[1])
+
+    root = ET.Element('ForceField')
+
+    # --- AtomTypes ---
+    at_el = ET.SubElement(root, 'AtomTypes')
+    for i, cx_a in enumerate(cx_atoms):
+        # 'class' is a Python reserved word; pass as a positional attrib dict.
+        ET.SubElement(at_el, 'Type', {
+            'name':    type_names[i],
+            'class':   type_names[i],
+            'element': cx_a.element.name.capitalize(),
+            'mass':    str(cx_a.element.mass),
+        })
+
+    # --- Residue template ---
+    res_el = ET.SubElement(ET.SubElement(root, 'Residues'), 'Residue', name=rname)
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(res_el, 'Atom',
+            name=cx_a.name,
+            type=type_names[i],
+            charge=str(charges[i]))
+    # Bond connectivity (atom names, not parameters)
+    bonds = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds.atoms
+    for a1_name, a2_name in zip(a1_col.names, a2_col.names):
+        ET.SubElement(res_el, 'Bond', atomName1=a1_name, atomName2=a2_name)
+
+    # --- NonbondedForce (AMBER14-compatible 14-scaling) ---
+    nb_el = ET.SubElement(root, 'NonbondedForce',
+        coulomb14scale='0.8333333333333333', lj14scale='0.5')
+    ET.SubElement(nb_el, 'UseAttributeFromResidue', name='charge')
+    for i in range(n_atoms):
+        ET.SubElement(nb_el, 'Atom',
+            type=type_names[i],
+            sigma=str(sigma[i]),
+            epsilon=str(epsilon[i]))
+
+    # --- Bonded forces ---
+    for force in system.getForces():
+        if isinstance(force, HarmonicBondForce):
+            bf_el = ET.SubElement(root, 'HarmonicBondForce')
+            for bi in range(force.getNumBonds()):
+                i1, i2, r0, k = force.getBondParameters(bi)
+                ET.SubElement(bf_el, 'Bond',
+                    type1=type_names[i1], type2=type_names[i2],
+                    length=str(r0.value_in_unit(omm_unit.nanometer)),
+                    k=str(k.value_in_unit(
+                        omm_unit.kilojoule_per_mole / omm_unit.nanometer**2)))
+
+        elif isinstance(force, HarmonicAngleForce):
+            af_el = ET.SubElement(root, 'HarmonicAngleForce')
+            for ai in range(force.getNumAngles()):
+                i1, i2, i3, theta0, k = force.getAngleParameters(ai)
+                ET.SubElement(af_el, 'Angle',
+                    type1=type_names[i1], type2=type_names[i2],
+                    type3=type_names[i3],
+                    angle=str(theta0.value_in_unit(omm_unit.radian)),
+                    k=str(k.value_in_unit(
+                        omm_unit.kilojoule_per_mole / omm_unit.radian**2)))
+
+        elif isinstance(force, PeriodicTorsionForce):
+            tf_el = ET.SubElement(root, 'PeriodicTorsionForce')
+            for ti in range(force.getNumTorsions()):
+                i1, i2, i3, i4, per, phase, k = force.getTorsionParameters(ti)
+                # All torsion entries are written as <Proper>.  Improper out-of-
+                # plane terms from GARNET cannot be distinguished at system level;
+                # those that have no bonded 1-2-3-4 path will be silently skipped
+                # by OpenMM's template matching, which is acceptable for model
+                # building.
+                ET.SubElement(tf_el, 'Proper',
+                    type1=type_names[i1], type2=type_names[i2],
+                    type3=type_names[i3], type4=type_names[i4],
+                    periodicity1=str(per),
+                    phase1=str(phase.value_in_unit(omm_unit.radian)),
+                    k1=str(k.value_in_unit(omm_unit.kilojoule_per_mole)))
+
+    return ET.tostring(root, encoding='unicode')
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+class GarnetParameterisationProvider(LigandBackedParameterisationProvider):
+    '''
+    Parameterisation provider that uses AMBER14 for standard residues and
+    GARNET for ligands that have no existing template.
+
+    When ``sim_params.forcefield`` is ``'amber14'`` or ``'charmm36'`` the class
+    behaves identically to :class:`ForceFieldParameterisationProvider`.
+    When it is ``'amber14+garnet'`` it intercepts
+    :class:`UnparameterisedResiduesError`, runs GARNET on each unmatched
+    non-polymer residue, registers the XML template under the ``USER_`` prefix,
+    and retries.
+
+    Parameters
+    ----------
+    forcefield_mgr : ForcefieldMgr
+    '''
+
+    @property
+    def backend_forcefield_key(self):
+        return 'amber14+garnet'
+
+    def _residue_is_eligible(self, residue):
+        if not super()._residue_is_eligible(residue):
+            return False
+        return not any(a.element.number not in _ELEMENT_INDICES
+                       for a in residue.atoms)
+
+    def _parameterise_one(self, residue, logger):
+        xml, de_info = self._garnet_parameterise_one(residue, logger)
+        return xml, {'de': de_info}
+
+    def _patch_system(self, system, top):
+        self._patch_garnet_vdw(system, top)
+
+    def _patch_garnet_vdw(self, system, top):
+        '''
+        Post-process *system* to replace the approximate LJ VdW for GARNET
+        atoms with GARNET's native double-exponential (DE) potential.
+
+        Two ``CustomNonbondedForce`` objects are added, both restricted to the
+        GARNET-atom set via ``addInteractionGroup``:
+
+        1. **DE force** — GARNET's original energy expression with GARNET's
+           per-particle parameters.  Adds the correct DE interaction.
+        2. **LJ-correction force** — subtracts the LJ contribution that
+           AMBER14's ``NonbondedForce`` already computed for the same pairs
+           (using GARNET's sigma/epsilon values and Lorentz-Berthelot mixing).
+
+        Net ligand–ligand VdW = LJ (NonbondedForce) − LJ (correction) + DE = DE.
+
+        Protein–ligand and protein–protein interactions are untouched.
+
+        1-4 intra-ligand pairs are excluded from both custom forces (they appear
+        as exceptions in the ``NonbondedForce`` with 0.5× LJ scaling, which is
+        left in place as an accepted approximation).
+
+        Design note for future DE-everywhere upgrade
+        --------------------------------------------
+        To extend DE to proteins:
+        1. Assign DE parameters to protein atoms in the DE force.
+        2. Extend the LJ-correction to protein–protein and protein–ligand groups.
+        3. Once the cross-term correction is also DE, delete the correction force.
+        '''
+        from openmm.openmm import NonbondedForce, CustomNonbondedForce
+        from openmm import unit as omm_unit
+
+        # --- Identify GARNET atoms and collect their DE parameters -----------
+
+        # de_map: global_atom_index → [p0, p1, ...] per-particle DE params
+        de_map = {}
+        de_info_ref = None  # DE expression/param_names (same for all GARNET residues)
+
+        for omm_res in top.residues():
+            entry = self._template_cache.get(omm_res.name)
+            if entry is None or entry.get('de') is None:
+                continue
+            de_info = entry['de']
+            if de_info_ref is None:
+                de_info_ref = de_info
+            atoms_list = list(omm_res.atoms())
+            per_atom = de_info['per_atom']
+            for local_idx, omm_atom in enumerate(atoms_list):
+                if local_idx < len(per_atom):
+                    de_map[omm_atom.index] = per_atom[local_idx]
+
+        if not de_map or de_info_ref is None:
+            return  # No GARNET atoms in this construct
+
+        garnet_set = set(de_map.keys())
+        garnet_list = sorted(garnet_set)
+        n_atoms = system.getNumParticles()
+        n_de_params = len(de_info_ref['param_names'])
+
+        # --- Find NonbondedForce ------------------------------------------
+
+        nb_force = None
+        for force in system.getForces():
+            if isinstance(force, NonbondedForce):
+                nb_force = force
+                break
+        if nb_force is None:
+            return
+
+        # --- Collect garnet-garnet pair exclusions from NonbondedForce ------
+        # All NonbondedForce exceptions where both particles are GARNET atoms
+        # (1-2/1-3 full exclusions and 1-4 scaled exceptions) become full
+        # exclusions in the CustomNonbondedForces, leaving 1-4 VdW solely in
+        # the NonbondedForce as AMBER-style 0.5 × LJ.
+        garnet_exclusions = []
+        for i in range(nb_force.getNumExceptions()):
+            p1, p2, _chq, _sig, _eps = nb_force.getExceptionParameters(i)
+            if p1 in garnet_set and p2 in garnet_set:
+                garnet_exclusions.append((p1, p2))
+
+        # --- Extract LJ sigma/epsilon for GARNET atoms from NonbondedForce --
+        # These are the approximate values written by _garnet_system_to_ffxml.
+        lj_sigma = {}
+        lj_epsilon = {}
+        for idx in garnet_list:
+            _q, sig, eps = nb_force.getParticleParameters(idx)
+            lj_sigma[idx] = sig.value_in_unit(omm_unit.nanometer)
+            lj_epsilon[idx] = eps.value_in_unit(omm_unit.kilojoule_per_mole)
+
+        # Dummy per-particle params for non-GARNET atoms in both custom forces.
+        # These atoms are outside the interaction group and are never evaluated;
+        # the values chosen here are physically inert.
+        dummy_de = [0.3] + [0.0] * (n_de_params - 1)
+
+        # --- 1. DE CustomNonbondedForce (ligand-ligand) ----------------------
+
+        de_force = CustomNonbondedForce(de_info_ref['expression'])
+        for pname in de_info_ref['param_names']:
+            de_force.addPerParticleParameter(pname)
+        for gname, gval in de_info_ref.get('global_params', {}).items():
+            de_force.addGlobalParameter(gname, gval)
+        de_force.setNonbondedMethod(CustomNonbondedForce.NoCutoff)
+
+        for i in range(n_atoms):
+            de_force.addParticle(de_map[i] if i in de_map else dummy_de)
+
+        de_force.addInteractionGroup(garnet_list, garnet_list)
+        for p1, p2 in garnet_exclusions:
+            de_force.addExclusion(p1, p2)
+
+        system.addForce(de_force)
+
+        # --- 2. LJ-correction CustomNonbondedForce (ligand-ligand, negate) --
+        # Cancels the LJ NonbondedForce computed for GARNET-GARNET pairs so
+        # that net ligand-ligand VdW = DE only.
+        lj_corr_expr = (
+            '-4*eps_ij*((sig_ij/r)^12-(sig_ij/r)^6);'
+            'sig_ij=0.5*(sig1+sig2);'
+            'eps_ij=sqrt(eps1*eps2)'
+        )
+        corr_force = CustomNonbondedForce(lj_corr_expr)
+        corr_force.addPerParticleParameter('sig')
+        corr_force.addPerParticleParameter('eps')
+        corr_force.setNonbondedMethod(CustomNonbondedForce.NoCutoff)
+
+        for i in range(n_atoms):
+            if i in garnet_set:
+                corr_force.addParticle([lj_sigma[i], lj_epsilon[i]])
+            else:
+                corr_force.addParticle([0.3, 0.0])
+
+        corr_force.addInteractionGroup(garnet_list, garnet_list)
+        for p1, p2 in garnet_exclusions:
+            corr_force.addExclusion(p1, p2)
+
+        system.addForce(corr_force)
+
+    def _garnet_parameterise_one(self, residue, logger):
+        '''
+        Build shim topology → GARNET inference → ISOLDE-compatible XML string
+        plus GARNET's native DE force metadata.
+
+        The shim topology exposes the interface garnetff expects without
+        requiring openff.toolkit or RDKit.
+
+        Returns
+        -------
+        xml : str
+            ForceField XML template.
+        de_info : dict or None
+            ``{'expression': str, 'param_names': list[str],
+               'global_params': dict[str, float], 'per_atom': list[list[float]]}``
+            where ``per_atom[i]`` are the per-particle parameters for GARNET atom
+            ``i`` in the DE force.  ``None`` if GARNET produced no
+            ``CustomNonbondedForce`` (unexpected but safe to handle).
+        '''
+        from garnetff import garnet
+        from openmm.app import NoCutoff
+        from openmm.openmm import CustomNonbondedForce as CNBForce
+
+        topology = _GarnetTopology(residue)
+        system, _top_omm = garnet.topology_to_openmm_system(
+            topology,
+            nonbondedMethod=NoCutoff,
+            constraints=None)
+
+        # Extract DE CustomNonbondedForce metadata before converting to XML.
+        de_info = None
+        for force in system.getForces():
+            if isinstance(force, CNBForce):
+                n_pp = force.getNumPerParticleParameters()
+                n_gp = force.getNumGlobalParameters()
+                de_info = {
+                    'expression':   force.getEnergyFunction(),
+                    'param_names':  [force.getPerParticleParameterName(i)
+                                     for i in range(n_pp)],
+                    'global_params': {
+                        force.getGlobalParameterName(i):
+                        force.getGlobalParameterDefaultValue(i)
+                        for i in range(n_gp)
+                    },
+                    'per_atom': [list(force.getParticleParameters(i))
+                                 for i in range(force.getNumParticles())],
+                }
+                break
+
+        xml = _garnet_system_to_ffxml(residue, system)
+        return xml, de_info

--- a/isolde/src/openmm/mmff_provider.py
+++ b/isolde/src/openmm/mmff_provider.py
@@ -1,0 +1,272 @@
+# @Author: Tristan Croll
+# @Date:   02-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 02-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+MMFF94-based ligand parameterisation provider (pure-RDKit, no AmberTools).
+
+The internal force terms (bonds, angles, torsions) come from MMFF94 via RDKit.
+Partial charges are MMFF94 partial charges.  Per-atom LJ parameters are taken
+from a GAFF2-derived element table so that Lorentz-Berthelot mixing with AMBER14
+protein atoms is physically consistent.
+
+This is a "best-effort" fallback for ligands that have no GARNET/espaloma/OpenFF
+backend available.  Production simulations should prefer GARNET or an OpenFF-based
+backend when accessible.
+'''
+
+import math
+from .param_provider import LigandBackedParameterisationProvider
+
+_KCAL_TO_KJ  = 4.184          # 1 kcal/mol = 4.184 kJ/mol
+_ANG_TO_NM   = 0.1            # 1 Å = 0.1 nm
+_DEG_TO_RAD  = math.pi / 180.0
+
+# RDKit's MMFFMolProperties returns the *raw* MMFF94 force constants: bond kb in
+# md/Å (millidyne/Å) and angle ka in md·Å/rad², NOT kcal/mol.  MMFF defines the
+# harmonic energy as E = (kb/2)·143.9325·Δr² (and the analogous angle form), so
+# this constant converts the raw force constant into kcal·mol⁻¹ per (Å² or rad²)
+# before the usual kcal→kJ / Å→nm conversions.  Omitting it makes every bond and
+# angle ~144x too weak.  (Torsion V1/V2/V3 are already in kcal/mol — no factor.)
+_MDYNE_A_TO_KCAL = 143.9325
+
+# Per-element LJ parameters (sigma/nm, epsilon/kJ·mol⁻¹) derived from GAFF2.
+# Used for protein–ligand cross-term mixing via Lorentz-Berthelot rules.
+_ELEMENT_LJ = {
+    1:  (0.106, 0.0657),   # H
+    6:  (0.339, 0.3598),   # C
+    7:  (0.325, 0.7113),   # N
+    8:  (0.296, 0.8786),   # O
+    9:  (0.312, 0.2552),   # F
+    15: (0.374, 0.8368),   # P
+    16: (0.356, 1.0460),   # S
+    17: (0.347, 1.1087),   # Cl
+    35: (0.378, 1.6883),   # Br
+    53: (0.418, 2.0920),   # I
+}
+_DEFAULT_LJ = (0.340, 0.50)  # fallback for uncommon elements
+
+
+def _cx_residue_to_rdmol(residue):
+    '''
+    Build an RDKit RWMol from a ChimeraX residue and infer bond orders from
+    3D geometry.  Requires explicit hydrogen atoms for reliable bond-order
+    assignment.  ``charge=0`` is assumed.
+    '''
+    from rdkit import Chem
+    from rdkit.Chem import AllChem, rdDetermineBonds
+
+    cx_atoms = list(residue.atoms)
+    atom_index = {a: i for i, a in enumerate(cx_atoms)}
+    n = len(cx_atoms)
+
+    mol = Chem.RWMol()
+    conf = Chem.Conformer(n)
+    for i, a in enumerate(cx_atoms):
+        mol.AddAtom(Chem.Atom(a.element.number))
+        c = a.coord
+        conf.SetAtomPosition(i, (float(c[0]), float(c[1]), float(c[2])))
+    mol.AddConformer(conf, assignId=True)
+
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1, a2 in zip(a1_col, a2_col):
+        mol.AddBond(atom_index[a1], atom_index[a2], Chem.BondType.SINGLE)
+
+    rdDetermineBonds.DetermineBondOrders(mol, charge=0)
+    mol_ro = mol.GetMol()
+    AllChem.AssignStereochemistryFrom3D(mol_ro)
+    return mol_ro
+
+
+def _mmff_system_to_ffxml(residue, mol) -> str:
+    '''
+    Extract MMFF94 parameters from *mol* and serialise them as a ForceField XML
+    template compatible with ISOLDE's ForceField (USER_ prefix on registration).
+
+    Force terms:
+      - HarmonicBondForce : MMFF94 bond stretch
+      - HarmonicAngleForce : MMFF94 angle bend
+      - PeriodicTorsionForce : MMFF94 proper torsions (v1/v2/v3 decomposition)
+      - NonbondedForce : MMFF94 partial charges + GAFF2-element LJ
+    '''
+    import xml.etree.ElementTree as ET
+    from rdkit.Chem import rdForceFieldHelpers
+
+    cx_atoms = list(residue.atoms)
+    n_atoms  = mol.GetNumAtoms()
+    rname    = residue.name
+    type_names = [f'MMF_{rname}_{i}' for i in range(n_atoms)]
+
+    # ---- MMFF94 properties (charges, atom types) ----------------------------
+    props = rdForceFieldHelpers.MMFFGetMoleculeProperties(mol, mmffVariant='MMFF94')
+    if props is None:
+        raise RuntimeError(f'MMFF94 could not assign properties for residue {rname!r}')
+
+    charges = [props.GetMMFFPartialCharge(i) for i in range(n_atoms)]
+
+    def _lj(i):
+        return _ELEMENT_LJ.get(mol.GetAtomWithIdx(i).GetAtomicNum(), _DEFAULT_LJ)
+
+    sigma   = [_lj(i)[0] for i in range(n_atoms)]
+    epsilon = [_lj(i)[1] for i in range(n_atoms)]
+
+    root = ET.Element('ForceField')
+
+    # AtomTypes
+    at_el = ET.SubElement(root, 'AtomTypes')
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(at_el, 'Type', {
+            'name':    type_names[i],
+            'class':   type_names[i],
+            'element': cx_a.element.name.capitalize(),
+            'mass':    str(cx_a.element.mass),
+        })
+
+    # Residue template
+    res_el = ET.SubElement(ET.SubElement(root, 'Residues'), 'Residue', name=rname)
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(res_el, 'Atom',
+            name=cx_a.name, type=type_names[i], charge=str(charges[i]))
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1_name, a2_name in zip(a1_col.names, a2_col.names):
+        ET.SubElement(res_el, 'Bond', atomName1=a1_name, atomName2=a2_name)
+
+    # NonbondedForce (AMBER14-compatible 14-scaling)
+    nb_el = ET.SubElement(root, 'NonbondedForce',
+        coulomb14scale='0.8333333333333333', lj14scale='0.5')
+    ET.SubElement(nb_el, 'UseAttributeFromResidue', name='charge')
+    for i in range(n_atoms):
+        ET.SubElement(nb_el, 'Atom',
+            type=type_names[i], sigma=str(sigma[i]), epsilon=str(epsilon[i]))
+
+    # ---- HarmonicBondForce --------------------------------------------------
+    # GetMMFFBondStretchParams -> (bondType, kb, r0); kb in md/Å, r0 in Å.
+    # MMFF94: E = (143.9325*kb/2)*Δr²  (kcal/mol, Δr in Å)
+    # OpenMM: E = (k/2)*Δr²  with k in kJ/mol/nm²
+    bf_el = None
+    for bond in mol.GetBonds():
+        i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+        bp = props.GetMMFFBondStretchParams(mol, i, j)
+        if bp is None:
+            continue
+        kb, r0 = bp[1], bp[2]
+        k_kJ_nm2 = kb * _MDYNE_A_TO_KCAL * _KCAL_TO_KJ / (_ANG_TO_NM ** 2)
+        r0_nm    = r0 * _ANG_TO_NM
+        if bf_el is None:
+            bf_el = ET.SubElement(root, 'HarmonicBondForce')
+        ET.SubElement(bf_el, 'Bond',
+            type1=type_names[i], type2=type_names[j],
+            length=str(r0_nm), k=str(k_kJ_nm2))
+
+    # ---- HarmonicAngleForce -------------------------------------------------
+    # GetMMFFAngleBendParams -> (angleType, ka, theta0); ka in md·Å/rad²,
+    # theta0 in degrees.  MMFF's harmonic term reduces to
+    # E = (143.9325*ka/2)*Δθ_rad² (kcal/mol), so the same md->kcal constant
+    # applies.  OpenMM: E = (k/2)*Δθ² with k in kJ/mol/rad², θ in rad.
+    af_el = None
+    for j in range(n_atoms):
+        nbrs = [b.GetOtherAtomIdx(j)
+                for b in mol.GetAtomWithIdx(j).GetBonds()]
+        for ia in range(len(nbrs)):
+            i = nbrs[ia]
+            for ib in range(ia + 1, len(nbrs)):
+                k = nbrs[ib]
+                ap = props.GetMMFFAngleBendParams(mol, i, j, k)
+                if ap is None:
+                    continue
+                ka, theta0 = ap[1], ap[2]
+                ka_kJ   = ka * _MDYNE_A_TO_KCAL * _KCAL_TO_KJ
+                th0_rad = theta0 * _DEG_TO_RAD
+                if af_el is None:
+                    af_el = ET.SubElement(root, 'HarmonicAngleForce')
+                ET.SubElement(af_el, 'Angle',
+                    type1=type_names[i], type2=type_names[j], type3=type_names[k],
+                    angle=str(th0_rad), k=str(ka_kJ))
+
+    # ---- PeriodicTorsionForce -----------------------------------------------
+    # MMFF94: E = (V1/2)*(1+cos φ) + (V2/2)*(1-cos 2φ) + (V3/2)*(1+cos 3φ)
+    # Mapped to OpenMM k*(1+cos(n*φ - phase)):
+    #   V1 → k=V1/2, n=1, phase=0
+    #   V2 → k=V2/2, n=2, phase=π
+    #   V3 → k=V3/2, n=3, phase=0
+    tf_el = None
+    seen_torsions = set()
+    for bond_jk in mol.GetBonds():
+        j = bond_jk.GetBeginAtomIdx()
+        k = bond_jk.GetEndAtomIdx()
+        i_list = [b.GetOtherAtomIdx(j) for b in mol.GetAtomWithIdx(j).GetBonds()
+                  if b.GetOtherAtomIdx(j) != k]
+        l_list = [b.GetOtherAtomIdx(k) for b in mol.GetAtomWithIdx(k).GetBonds()
+                  if b.GetOtherAtomIdx(k) != j]
+        for i in i_list:
+            for l in l_list:
+                if l == i:
+                    continue
+                key = tuple(sorted([i, j, k, l]) + [j, k])
+                if key in seen_torsions:
+                    continue
+                seen_torsions.add(key)
+                tp = props.GetMMFFTorsionParams(mol, i, j, k, l)
+                if tp is None:
+                    continue
+                # GetMMFFTorsionParams -> (torsionType, V1, V2, V3); V in kcal/mol.
+                v1, v2, v3 = tp[1], tp[2], tp[3]
+                if tf_el is None:
+                    tf_el = ET.SubElement(root, 'PeriodicTorsionForce')
+                for v, n_per, base_phase in ((v1, 1, 0.0),
+                                              (v2, 2, math.pi),
+                                              (v3, 3, 0.0)):
+                    if abs(v) < 1e-6:
+                        continue
+                    k_kJ   = abs(v) * _KCAL_TO_KJ / 2.0
+                    phase  = base_phase + (math.pi if v < 0.0 else 0.0)
+                    ET.SubElement(tf_el, 'Proper',
+                        type1=type_names[i], type2=type_names[j],
+                        type3=type_names[k], type4=type_names[l],
+                        periodicity1=str(n_per),
+                        phase1=str(phase),
+                        k1=str(k_kJ))
+
+    return ET.tostring(root, encoding='unicode')
+
+
+def _mmff_parameterise_residue(residue, logger) -> str:
+    '''Run MMFF94 on the residue and return a ForceField XML string.'''
+    from rdkit.Chem import AllChem
+
+    mol = _cx_residue_to_rdmol(residue)
+    result = AllChem.MMFFOptimizeMolecule(mol, maxIters=200)
+    if result == -1:
+        raise RuntimeError(
+            f'MMFF94 could not set up a force field for {residue.name!r}. '
+            f'The molecule may contain elements or bonding patterns not '
+            f'supported by MMFF94.')
+    return _mmff_system_to_ffxml(residue, mol)
+
+
+class MMFFParameterisationProvider(LigandBackedParameterisationProvider):
+    '''
+    Parameterisation provider using AMBER14 for standard residues and MMFF94
+    (via RDKit) for ligands.
+
+    Requires only ``rdkit`` — no AmberTools, no OpenFF toolkit, no conda.
+
+    Internal force constants (bonds, angles, torsions) come directly from
+    MMFF94.  Per-atom LJ parameters are from a GAFF2-element table so that
+    Lorentz-Berthelot mixing with AMBER14 protein atoms is physically
+    consistent.  This is an approximation: for production work, prefer
+    ``amber14+garnet`` or an OpenFF-based backend.
+    '''
+
+    @property
+    def backend_forcefield_key(self):
+        return 'amber14+mmff'
+
+    def _parameterise_one(self, residue, logger):
+        xml = _mmff_parameterise_residue(residue, logger)
+        return xml, {}

--- a/isolde/src/openmm/openff_provider.py
+++ b/isolde/src/openmm/openff_provider.py
@@ -1,0 +1,199 @@
+# @Author: Tristan Croll
+# @Date:   02-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 02-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+
+from .param_provider import LigandBackedParameterisationProvider
+
+_OPENFF_FORCEFIELD = 'openff-2.2.0.offxml'
+
+
+def _cx_residue_to_offmol(residue):
+    '''
+    Convert a ChimeraX residue to an OpenFF Molecule.
+
+    Builds an RDKit RWMol from atom elements and 3D coordinates, uses
+    rdDetermineBonds to infer bond orders from geometry, then converts to
+    an OpenFF Molecule via ``from_rdkit``.
+
+    Requires the residue to have explicit hydrogen atoms for reliable bond-order
+    inference.  ``charge=0`` is assumed; charged ligands may fail and fall back
+    to AMBER14.
+    '''
+    from rdkit import Chem
+    from rdkit.Chem import AllChem, rdDetermineBonds
+    from openff.toolkit import Molecule as OFFMolecule
+
+    cx_atoms = list(residue.atoms)
+    atom_index = {a: i for i, a in enumerate(cx_atoms)}
+    n = len(cx_atoms)
+
+    mol = Chem.RWMol()
+    conf = Chem.Conformer(n)
+    for i, a in enumerate(cx_atoms):
+        mol.AddAtom(Chem.Atom(a.element.number))
+        coord = a.coord  # Angstrom
+        conf.SetAtomPosition(i, (float(coord[0]), float(coord[1]), float(coord[2])))
+    mol.AddConformer(conf, assignId=True)
+
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1, a2 in zip(a1_col, a2_col):
+        mol.AddBond(atom_index[a1], atom_index[a2], Chem.BondType.SINGLE)
+
+    rdDetermineBonds.DetermineBondOrders(mol, charge=0)
+    mol_ro = mol.GetMol()
+    AllChem.AssignStereochemistryFrom3D(mol_ro)
+
+    return OFFMolecule.from_rdkit(mol_ro, allow_undefined_stereo=True)
+
+
+def _assign_partial_charges(off_mol):
+    '''
+    Try AM1-BCC (needs ambertools or openeye), fall back to Gasteiger (RDKit).
+    Gasteiger is lower quality but available with a pure pip install.
+    '''
+    for method in ('am1bcc', 'gasteiger'):
+        try:
+            off_mol.assign_partial_charges(method)
+            return
+        except Exception:
+            continue
+    raise RuntimeError(
+        'No partial charge method available — install ambertools or '
+        'openeye-toolkits for AM1-BCC charges, or openff-nagl for a '
+        'neural-network alternative.')
+
+
+def _openff_system_to_ffxml(residue, system) -> str:
+    '''
+    Convert an OpenFF-produced OpenMM System to a ForceField XML template
+    string suitable for
+    ``ForceField.loadFile(io.StringIO(xml), resname_prefix='USER_')``.
+
+    OpenFF (like Espaloma) stores charges, sigma, and epsilon all in
+    NonbondedForce — no CustomNonbondedForce.
+    '''
+    import xml.etree.ElementTree as ET
+    from openmm import unit as omm_unit
+    from openmm.openmm import (HarmonicBondForce, HarmonicAngleForce,
+                               PeriodicTorsionForce, NonbondedForce)
+
+    cx_atoms = list(residue.atoms)
+    n_atoms = system.getNumParticles()
+    rname = residue.name
+    type_names = [f'OPN_{rname}_{i}' for i in range(n_atoms)]
+
+    charges = [0.0] * n_atoms
+    sigma   = [0.35] * n_atoms
+    epsilon = [0.40] * n_atoms
+
+    for force in system.getForces():
+        if isinstance(force, NonbondedForce):
+            for ni in range(force.getNumParticles()):
+                q, sig, eps = force.getParticleParameters(ni)
+                charges[ni] = q.value_in_unit(omm_unit.elementary_charge)
+                sigma[ni]   = sig.value_in_unit(omm_unit.nanometer)
+                epsilon[ni] = eps.value_in_unit(omm_unit.kilojoule_per_mole)
+            break
+
+    root = ET.Element('ForceField')
+
+    at_el = ET.SubElement(root, 'AtomTypes')
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(at_el, 'Type', {
+            'name':    type_names[i],
+            'class':   type_names[i],
+            'element': cx_a.element.name.capitalize(),
+            'mass':    str(cx_a.element.mass),
+        })
+
+    res_el = ET.SubElement(ET.SubElement(root, 'Residues'), 'Residue', name=rname)
+    for i, cx_a in enumerate(cx_atoms):
+        ET.SubElement(res_el, 'Atom',
+            name=cx_a.name,
+            type=type_names[i],
+            charge=str(charges[i]))
+    bonds_obj = residue.atoms.intra_bonds
+    a1_col, a2_col = bonds_obj.atoms
+    for a1_name, a2_name in zip(a1_col.names, a2_col.names):
+        ET.SubElement(res_el, 'Bond', atomName1=a1_name, atomName2=a2_name)
+
+    nb_el = ET.SubElement(root, 'NonbondedForce',
+        coulomb14scale='0.8333333333333333', lj14scale='0.5')
+    ET.SubElement(nb_el, 'UseAttributeFromResidue', name='charge')
+    for i in range(n_atoms):
+        ET.SubElement(nb_el, 'Atom',
+            type=type_names[i],
+            sigma=str(sigma[i]),
+            epsilon=str(epsilon[i]))
+
+    for force in system.getForces():
+        if isinstance(force, HarmonicBondForce):
+            bf_el = ET.SubElement(root, 'HarmonicBondForce')
+            for bi in range(force.getNumBonds()):
+                i1, i2, r0, k = force.getBondParameters(bi)
+                ET.SubElement(bf_el, 'Bond',
+                    type1=type_names[i1], type2=type_names[i2],
+                    length=str(r0.value_in_unit(omm_unit.nanometer)),
+                    k=str(k.value_in_unit(
+                        omm_unit.kilojoule_per_mole / omm_unit.nanometer**2)))
+
+        elif isinstance(force, HarmonicAngleForce):
+            af_el = ET.SubElement(root, 'HarmonicAngleForce')
+            for ai in range(force.getNumAngles()):
+                i1, i2, i3, theta0, k = force.getAngleParameters(ai)
+                ET.SubElement(af_el, 'Angle',
+                    type1=type_names[i1], type2=type_names[i2],
+                    type3=type_names[i3],
+                    angle=str(theta0.value_in_unit(omm_unit.radian)),
+                    k=str(k.value_in_unit(
+                        omm_unit.kilojoule_per_mole / omm_unit.radian**2)))
+
+        elif isinstance(force, PeriodicTorsionForce):
+            tf_el = ET.SubElement(root, 'PeriodicTorsionForce')
+            for ti in range(force.getNumTorsions()):
+                i1, i2, i3, i4, per, phase, k = force.getTorsionParameters(ti)
+                ET.SubElement(tf_el, 'Proper',
+                    type1=type_names[i1], type2=type_names[i2],
+                    type3=type_names[i3], type4=type_names[i4],
+                    periodicity1=str(per),
+                    phase1=str(phase.value_in_unit(omm_unit.radian)),
+                    k1=str(k.value_in_unit(omm_unit.kilojoule_per_mole)))
+
+    return ET.tostring(root, encoding='unicode')
+
+
+def _openff_parameterise_residue(residue, logger) -> str:
+    '''Orchestrate the full OpenFF parameterisation pipeline for one residue.'''
+    from openff.toolkit import ForceField
+
+    off_mol = _cx_residue_to_offmol(residue)
+    _assign_partial_charges(off_mol)
+    ff = ForceField(_OPENFF_FORCEFIELD)
+    off_top = off_mol.to_topology()
+    system = ff.create_openmm_system(off_top,
+                                     charge_from_molecules=[off_mol],
+                                     constraints=None)
+    return _openff_system_to_ffxml(residue, system)
+
+
+class OpenFFParameterisationProvider(LigandBackedParameterisationProvider):
+    '''
+    Parameterisation provider using AMBER14 for standard residues and
+    OpenFF Sage (openff-2.2.0) for ligands.
+
+    Partial charges are assigned via AM1-BCC if ambertools or openeye-toolkits
+    are available, falling back to Gasteiger (RDKit) for pure pip installs.
+    '''
+
+    @property
+    def backend_forcefield_key(self):
+        return 'amber14+openff'
+
+    def _parameterise_one(self, residue, logger):
+        xml = _openff_parameterise_residue(residue, logger)
+        return xml, {}

--- a/isolde/src/openmm/openmm_interface.py
+++ b/isolde/src/openmm/openmm_interface.py
@@ -327,7 +327,7 @@ class SimManager:
         uh = self._update_handlers = []
         try:
             sh = self.sim_handler = SimHandler(session, sim_params, sc,
-                isolde.forcefield_mgr)
+                isolde.param_provider)
         except Exception as e:
             self._sim_end_cb(None, None)
             # if isinstance(e, RuntimeError):
@@ -522,7 +522,7 @@ class SimManager:
         uh = update_handlers
         mobile_res = sc.mobile_atoms.unique_residues
         amber_cmap = False
-        if self.sim_params.forcefield == 'amber14':
+        if self.sim_params.forcefield.startswith('amber14'):
             amber_cmap = True
         sh.initialize_restraint_forces(amber_cmap)
         if (amber_cmap):
@@ -1032,7 +1032,7 @@ class SimHandler:
     '''
     REASON_COORD_LENGTH_MISMATCH = 'coord length mismatch'
     REASON_MODEL_DELETED = 'model deleted'
-    def __init__(self, session, sim_params, sim_construct, forcefield_mgr):
+    def __init__(self, session, sim_params, sim_construct, param_provider):
         '''
         Prepares the simulation topology parameters and construct, and
         initialises the necessary Force objects to handle restraints. Most
@@ -1054,9 +1054,9 @@ class SimHandler:
                 - a :py:class:`SimParams` instance
             * sim_construct:
                 - a :py:class:`SimConstruct` instance
-            * forcefield_mgr:
-                - a class that behaves as a
-                  {name: :py:class:`OpenMM::ForceField`} dict.
+            * param_provider:
+                - a :py:class:`~chimerax.isolde.openmm.param_provider.ParameterisationProvider`
+                  instance responsible for building the OpenMM topology and system.
 
         '''
         self.session = session
@@ -1076,11 +1076,6 @@ class SimHandler:
         self._sim_steps_at_checkpoint = 0
 
         atoms = self._atoms = sim_construct.all_atoms
-        # Forcefield used in this simulation
-#        from .forcefields import forcefields
-        ff = forcefield_mgr[sim_params.forcefield]
-        ligand_db = forcefield_mgr.ligand_db(sim_params.forcefield)
-#        ff = self._forcefield = self.define_forcefield(forcefields[sim_params.forcefield])
 
         # All custom forces in the simulation
         self.all_forces = []
@@ -1089,12 +1084,9 @@ class SimHandler:
         self.mdff_forces = {}
 
         logger = self.session.logger
-        # Overall simulation topology + system. The build can recover once from
-        # stale isolde_template_name overrides that no longer match their
-        # residue (see _build_system_with_template_recovery).
-        top, system = self._build_system_with_template_recovery(
-            ff, atoms, sim_construct.all_residues, sim_params, ligand_db, logger)
+        top, system = param_provider.build_system(sim_construct, sim_params, logger)
         self.topology = top
+        self._set_core_force_groups(system)
 
 
         self._temperature = sim_params.temperature
@@ -1238,93 +1230,6 @@ class SimHandler:
     @property
     def atoms(self):
         return self._atoms
-
-    def _build_system_with_template_recovery(self, ff, atoms, all_residues,
-            sim_params, ligand_db, logger):
-        '''
-        Build the OpenMM topology and system from ``all_residues``.
-
-        If the build fails because one or more residues carry an
-        ``isolde_template_name`` override that does not actually match the
-        residue (or names a template missing from the forcefield), clear those
-        overrides and rebuild **once**. Rebuilding from scratch — rather than
-        just re-running template matching — is important: ``find_residue_templates``
-        deliberately skips its cysteine / USER_ / ligand logic for residues that
-        already carry an override, so the residue only gets a fair shot at
-        automatic assignment after the override is gone. If the residue still
-        cannot be matched (or the failure was never override-related), the
-        UnparameterisedResiduesError propagates and the usual widget path fires.
-
-        Returns ``(topology, system)``.
-        '''
-        for attempt in (0, 1):
-            template_dict = find_residue_templates(all_residues, ff,
-                ligand_db=ligand_db, logger=logger,
-                clear_failed_overrides=True)
-            top, residue_templates = create_openmm_topology(atoms, template_dict)
-            try:
-                system = self._create_openmm_system(ff, top, sim_params,
-                    residue_templates, residues=all_residues)
-            except UnparameterisedResiduesError as e:
-                offenders = [r for r in (e.unmatched + e.ambiguous)
-                    if getattr(r, 'isolde_template_name', None) is not None]
-                if attempt == 0 and offenders:
-                    for r in offenders:
-                        logger.warning(
-                            'Residue {} was assigned template "{}" via its '
-                            'isolde_template_name override, but that template '
-                            'does not match the residue. Clearing the override '
-                            'and retrying with automatic template assignment.'
-                            .format(r, r.isolde_template_name))
-                        r.isolde_template_name = None
-                    continue
-                raise
-            return top, system
-
-    def _create_openmm_system(self, forcefield, top, params, residue_templates,
-            residues=None):
-        residue_to_template, ambiguous, unassigned = forcefield.assignTemplates(
-            top, ignoreExternalBonds=True, explicit_templates=residue_templates
-        )
-        if len(ambiguous) or len(unassigned):
-            # Map the offending OpenMM topology residues back to their ChimeraX
-            # residues (OpenMM res.index is the order they were added in
-            # create_openmm_topology, which matches `residues`) so the caller
-            # can inspect/clear stale isolde_template_name overrides.
-            unmatched_cx = []
-            ambiguous_cx = []
-            if residues is not None:
-                unmatched_cx = [residues[r.index] for r in unassigned]
-                ambiguous_cx = [residues[r.index] for r in ambiguous]
-            raise UnparameterisedResiduesError(unmatched=unmatched_cx,
-                ambiguous=ambiguous_cx)
-
-            # from chimerax.core.errors import UserError
-            # err_text = ''
-            # if len(ambiguous):
-            #     err_text += "The following residues match multiple topologies: \n"
-            #     for r, tlist in ambiguous.items():
-            #         err_text += "{}{}: ({})\n".format(r.name, r.index, ', '.join([info[0].name for info in tlist]))
-            # if len(unassigned):
-            #     err_text += "The following residues did not match any template: ({})".format(
-            #         ', '.join(['{}{}'.format(r.name, r.index) for r in unassigned])
-            #     )
-            # raise UserError(err_text)
-            #
-            # residue_templates = {r: t[0].name for r, t in residue_to_template.items()}
-
-        system_params = {
-            'nonbondedMethod':      params.nonbonded_cutoff_method,
-            'nonbondedCutoff':      params.nonbonded_cutoff_distance,
-            'constraints':          params.rigid_bonds,
-            'rigidWater':           params.rigid_water,
-            'removeCMMotion':       params.remove_c_of_m_motion,
-            'ignoreExternalBonds':  True,
-            'residueTemplates':     residue_templates,
-        }
-        sys = forcefield.createSystem(top, **system_params)
-        self._set_core_force_groups(sys)
-        return sys
 
     def _set_core_force_groups(self, system):
         from openmm.openmm import HarmonicBondForce, HarmonicAngleForce, PeriodicTorsionForce
@@ -1514,8 +1419,12 @@ class SimHandler:
         try:
             self._prepare_sim()
         except OpenMMException as e:
-            if self._params.platform=='CUDA':
-                self.session.logger.warning(f'Launching using CUDA failed with the below message. Falling back to using OpenCL.\n\n{str(e)}')
+            # The CUDA (NVIDIA) and HIP (AMD/ROCm) GPU platforms may be selected
+            # but not registered in this OpenMM build. Fall back to OpenCL, which
+            # runs on the same GPU hardware.
+            if self._params.platform in ('CUDA', 'HIP'):
+                failed_platform = self._params.platform
+                self.session.logger.warning(f'Launching using {failed_platform} failed with the below message. Falling back to using OpenCL.\n\n{str(e)}')
                 self._params.platform='OpenCL'
                 self._prepare_sim()
             else:

--- a/isolde/src/openmm/param_provider.py
+++ b/isolde/src/openmm/param_provider.py
@@ -1,0 +1,798 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Abstract interface for MD parameterisation backends.
+
+:class:`ParameterisationProvider` is an ABC that any parameterisation backend
+must implement.  :class:`ForceFieldParameterisationProvider` wraps the existing
+XML-based OpenMM forcefield pipeline and is the only concrete implementation for
+now; future backends (ML forcefields, etc.) implement the ABC without touching
+:class:`SimHandler`.
+
+Circular-import note
+--------------------
+This module deliberately avoids module-level imports from ``openmm_interface``.
+All references to ``openmm_interface`` symbols (``find_residue_templates``,
+``create_openmm_topology``, ``UnparameterisedResiduesError``) are deferred to
+inside method bodies so that the ``param_provider → openmm_interface`` dependency
+is a runtime-only dependency.  ``openmm_interface.py`` never imports this module.
+'''
+
+from abc import ABC, abstractmethod
+
+
+def _garnet_available() -> bool:
+    '''True when garnetff is importable without error.'''
+    try:
+        import garnetff  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _espaloma_available() -> bool:
+    '''True when espaloma, rdkit, and openff-toolkit are all importable.'''
+    try:
+        import espaloma  # noqa: F401
+        from rdkit import Chem  # noqa: F401
+        from openff.toolkit import Molecule  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _openff_available() -> bool:
+    '''True when openff-toolkit and rdkit are importable.'''
+    try:
+        from openff.toolkit import ForceField, Molecule  # noqa: F401
+        from rdkit import Chem  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _mmff_available() -> bool:
+    '''True when rdkit is importable (MMFF94 is bundled with rdkit).'''
+    try:
+        from rdkit.Chem import rdForceFieldHelpers  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _espaloma_charge_available() -> bool:
+    '''True when espaloma-charge and rdkit are both importable without error.
+
+    DGL (a dependency of espaloma-charge) ships version-specific graphbolt
+    DLLs; importing dgl raises FileNotFoundError if no DLL matches the
+    installed PyTorch version.  Catching Exception rather than ImportError
+    ensures that mismatch is treated as "not available" rather than a crash.
+    '''
+    try:
+        from .espaloma_charge_provider import _ensure_dgl_importable
+        _ensure_dgl_importable()
+        import espaloma_charge  # noqa: F401
+        from rdkit.Chem import rdForceFieldHelpers  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def available_parameterisation_backends() -> list:
+    '''
+    Return the list of backend names that can be passed to
+    ``sim_params.forcefield``.
+    '''
+    backends = ['amber14']
+    if _garnet_available():
+        backends.append('amber14+garnet')
+    if _espaloma_available():
+        backends.append('amber14+espaloma')
+    if _espaloma_charge_available():
+        backends.append('amber14+espaloma-charge')
+    if _openff_available():
+        backends.append('amber14+openff')
+    if _mmff_available():
+        backends.append('amber14+mmff')
+    backends.append('charmm36')
+    return backends
+
+
+class ParameterisationProvider(ABC):
+    '''
+    Abstract base for objects that convert a :class:`SimConstruct` +
+    :class:`SimParams` into an OpenMM topology and system ready for simulation.
+
+    The single required method is :meth:`build_system`.
+
+    .. note::
+        Implementations must **not** call ``_set_core_force_groups``.  That is
+        the responsibility of :class:`SimHandler` after ``build_system`` returns,
+        because the force-group constants live in ``openmm_interface.py``.
+    '''
+
+    @abstractmethod
+    def build_system(self, sim_construct, sim_params, logger=None):
+        '''
+        Parameterise *sim_construct* and return the OpenMM objects needed to
+        drive a simulation.
+
+        Parameters
+        ----------
+        sim_construct : SimConstruct
+            Atoms, residues, and fixed-atom bookkeeping for this run.
+        sim_params : SimParams
+            User-facing simulation parameters (forcefield name, cutoffs,
+            constraints, etc.).
+        logger : ChimeraX logger or None
+            Used for warnings/info during template resolution.
+
+        Returns
+        -------
+        topology : openmm.app.Topology
+        system : openmm.System
+            The returned system has **not** had force groups assigned;
+            :class:`SimHandler` assigns them after this call returns.
+        '''
+
+
+def _residue_structural_signature(residue):
+    '''
+    A string fingerprint of a ChimeraX residue's atom names/elements and
+    internal bonding, order-independent. Used (alongside a forcefield
+    identity key and any explicit template-name override) to detect whether
+    a residue's cached AMBER type assignment is still valid -- catches
+    silent atom/bond edits that no ``find_residue_templates`` heuristic
+    reacts to. Deliberately not hashed: Python's ``hash()`` of strings is
+    process-salted, so a hash computed in one process would not reliably
+    compare equal after a restart or session reload.
+    '''
+    atoms = residue.atoms
+    atom_part = tuple(sorted(zip(atoms.names.tolist(), atoms.element_names.tolist())))
+    b0, b1 = atoms.intra_bonds.atoms
+    bond_part = tuple(sorted(
+        tuple(sorted((n1, n2))) for n1, n2 in zip(b0.names.tolist(), b1.names.tolist())
+    ))
+    return repr((atom_part, bond_part))
+
+
+import weakref
+_amber_cache_attrs_registered_sessions = weakref.WeakSet()
+
+
+def _ensure_amber_cache_attrs_registered(session):
+    '''
+    ``Atom.register_attr``/``Residue.register_attr`` calls normally happen via
+    the bundle's ``custom-init`` hook (see ``chimerax.isolde.register_amber_type_cache_attrs``),
+    but that hook is only guaranteed to fire during a normal interactive
+    ChimeraX startup -- it does not reliably run before a headless
+    ``--script``/``runscript`` invocation (confirmed empirically: reading an
+    unregistered custom attribute raises ``AttributeError`` even after opening
+    a structure in such a session). Guard against that here rather than
+    silently miscaching, since ISOLDE is also driven headlessly via its
+    MCP/agent control surface.
+
+    Tracked via a ``WeakSet`` rather than ``id(session)`` in a plain ``set``:
+    a plain set of ids would never release entries for destroyed sessions, and
+    -- since ``id()`` is just a memory address -- a later, unrelated session
+    object could be allocated at the same address and be wrongly treated as
+    already registered.
+    '''
+    if session in _amber_cache_attrs_registered_sessions:
+        return
+    from chimerax.isolde import register_amber_type_cache_attrs
+    register_amber_type_cache_attrs(session)
+    _amber_cache_attrs_registered_sessions.add(session)
+
+
+def _forcefield_identity_key(forcefield, ff_name):
+    '''
+    A string identifying "this forcefield, as currently loaded" -- changes
+    whenever the forcefield is switched, ISOLDE/OpenMM is upgraded (mirroring
+    :class:`ForcefieldMgr`'s own pickle-cache invalidation check), or a new
+    residue template is registered at runtime (glycan/ligand-db/GARNET/user
+    ``loadFile`` calls all bump :attr:`ForceField._isolde_template_generation`
+    via the overridden ``registerResidueTemplate``).
+    '''
+    from openmm import version as openmm_version
+    from chimerax.isolde import __version__ as isolde_version
+    generation = getattr(forcefield, '_isolde_template_generation', 0)
+    return '{}|{}|{}|{}'.format(ff_name, openmm_version.version, isolde_version, generation)
+
+
+class ForceFieldParameterisationProvider(ParameterisationProvider):
+    '''
+    Concrete provider that wraps ISOLDE's existing XML-based OpenMM forcefield
+    pipeline (:class:`ForcefieldMgr` + AMBER14/CHARMM36 XML files).
+
+    Parameters
+    ----------
+    forcefield_mgr : ForcefieldMgr
+        Dict-like manager that lazy-loads :class:`ForceField` objects by name.
+    '''
+
+    def __init__(self, forcefield_mgr):
+        self._forcefield_mgr = forcefield_mgr
+
+    @property
+    def forcefield_mgr(self):
+        '''The underlying :class:`ForcefieldMgr` (for backward-compat access).'''
+        return self._forcefield_mgr
+
+    def build_system(self, sim_construct, sim_params, logger=None):
+        ff = self._forcefield_mgr[sim_params.forcefield]
+        ligand_db = self._forcefield_mgr.ligand_db(sim_params.forcefield)
+        atoms = sim_construct.all_atoms
+        all_residues = sim_construct.all_residues
+        return self._build_with_template_recovery(
+            ff, atoms, all_residues, sim_params, ligand_db, logger)
+
+    def _build_with_template_recovery(self, ff, atoms, all_residues,
+                                      sim_params, ligand_db, logger):
+        '''
+        Build the OpenMM topology and system, retrying once on stale
+        ``isolde_template_name`` overrides.
+
+        Migrated verbatim from ``SimHandler._build_system_with_template_recovery``.
+        Rebuilding from scratch — rather than just re-running template matching —
+        is important: ``find_residue_templates`` deliberately skips its cysteine /
+        USER_ / ligand logic for residues that already carry an override, so the
+        residue only gets a fair shot at automatic assignment after the override
+        is gone.
+
+        Returns ``(topology, system)``.  The system has **not** had force groups set.
+        '''
+        # Deferred imports to avoid a circular dependency at module load time.
+        from chimerax.isolde.openmm.openmm_interface import (
+            find_residue_templates,
+            create_openmm_topology,
+            UnparameterisedResiduesError,
+        )
+        for attempt in (0, 1):
+            template_dict = find_residue_templates(all_residues, ff,
+                ligand_db=ligand_db, logger=logger,
+                clear_failed_overrides=True)
+            top, residue_templates = create_openmm_topology(atoms, template_dict)
+            try:
+                system = self._create_system(ff, top, sim_params,
+                    residue_templates, residues=all_residues, atoms=atoms)
+            except UnparameterisedResiduesError as e:
+                offenders = [r for r in (e.unmatched + e.ambiguous)
+                    if getattr(r, 'isolde_template_name', None) is not None]
+                if attempt == 0 and offenders:
+                    for r in offenders:
+                        if logger is not None:
+                            logger.warning(
+                                'Residue {} was assigned template "{}" via its '
+                                'isolde_template_name override, but that template '
+                                'does not match the residue. Clearing the override '
+                                'and retrying with automatic template assignment.'
+                                .format(r, r.isolde_template_name))
+                        r.isolde_template_name = None
+                    continue
+                raise
+            return top, system
+
+    def _create_system(self, forcefield, top, params, residue_templates,
+                       residues, atoms):
+        '''
+        Build the OpenMM :class:`System` for *top*, using cached per-atom AMBER
+        types where available and only running full OpenMM template matching
+        (the expensive, isomorphism-based step) for residues whose cache is
+        missing or stale.
+
+        ``residues``/``atoms`` are the ChimeraX ``Residues``/``Atoms`` arrays
+        used to build *top* via ``create_openmm_topology``. Their ordering is
+        guaranteed to align positionally with ``top.residues()``/``top.atoms()``
+        -- ``residues[i]``/``atoms[i]`` is the ChimeraX counterpart of OpenMM
+        residue/atom index ``i`` (see ``SimConstruct`` and
+        ``create_openmm_topology``; this is the same invariant the old
+        unmatched/ambiguous-residue error mapping below already relied on).
+
+        Migrated from ``SimHandler._create_openmm_system``. Force-group
+        assignment remains :class:`SimHandler`'s responsibility.
+        '''
+        from chimerax.isolde.openmm.openmm_interface import UnparameterisedResiduesError
+        import json
+
+        if len(residues):
+            _ensure_amber_cache_attrs_registered(residues.unique_structures[0].session)
+
+        ff_key = _forcefield_identity_key(forcefield, params.forcefield)
+        top_residues = list(top.residues())
+        data = forcefield._SystemData(top)
+
+        miss = []  # list of (omm_res, cx_res, explicit_name)
+        n_hit = 0
+        for cx_res, omm_res in zip(residues, top_residues):
+            explicit_name = residue_templates.get(omm_res, None)
+            expected_key = '{}|{}|{}'.format(
+                ff_key, explicit_name, _residue_structural_signature(cx_res))
+            omm_res_atoms = list(omm_res.atoms())
+            cx_res_atoms = [atoms[a.index] for a in omm_res_atoms]
+            # Direct attribute access raises AttributeError for a *registered*
+            # custom attribute that has simply never been set on this instance
+            # -- registration declares the attribute, it does not give unset
+            # instances a default value. getattr(..., None) is the existing
+            # codebase convention for exactly this reason (cf. find_residue_templates'
+            # use of isolde_template_name).
+            if (getattr(cx_res, 'isolde_amber_cache_key', None) == expected_key
+                    and all(getattr(a, 'isolde_amber_type', None) is not None for a in cx_res_atoms)):
+                for omm_atom, cx_atom in zip(omm_res_atoms, cx_res_atoms):
+                    data.atomType[omm_atom] = cx_atom.isolde_amber_type
+                    p = getattr(cx_atom, 'isolde_amber_params', None)
+                    data.atomParameters[omm_atom] = json.loads(p) if p else {}
+                n_hit += 1
+            else:
+                miss.append((omm_res, cx_res, explicit_name))
+
+        # Recorded before attempting to resolve the misses, so that a
+        # residue which turns out to be genuinely unparameterisable (e.g. an
+        # atom deletion left it with no matching template) still reports
+        # accurate hit/miss counts to the caller/tests, rather than stale
+        # numbers from a previous successful build.
+        self.last_build_stats = {
+            'residues_total': len(top_residues),
+            'residues_cache_hit': n_hit,
+            'residues_cache_miss': len(miss),
+        }
+
+        if miss:
+            miss_top_residues = [m[0] for m in miss]
+            residue_to_template, ambiguous, unassigned = forcefield.assignTemplates(
+                top, ignoreExternalBonds=True, explicit_templates=residue_templates,
+                residues=miss_top_residues
+            )
+            if len(ambiguous) or len(unassigned):
+                # Map offending OpenMM topology residues back to ChimeraX residues
+                # (OpenMM res.index matches the order added in create_openmm_topology,
+                # which matches `residues`).
+                unmatched_cx = [residues[r.index] for r in unassigned]
+                ambiguous_cx = [residues[r.index] for r in ambiguous]
+                raise UnparameterisedResiduesError(unmatched=unmatched_cx,
+                    ambiguous=ambiguous_cx)
+
+            cx_res_and_name_by_top_res = {m[0]: (m[1], m[2]) for m in miss}
+            for omm_res, (template, match) in residue_to_template.items():
+                data.recordMatchedAtomParameters(omm_res, template, match)
+                cx_res, explicit_name = cx_res_and_name_by_top_res[omm_res]
+                if template.virtualSites:
+                    # None of ISOLDE's currently-loaded AMBER14 XML files define
+                    # virtual sites, but if one ever does, never cache it --
+                    # always re-resolve rather than risk a stale/incomplete
+                    # cache entry silently producing a wrong system. The
+                    # current build is still correct either way; only future
+                    # cache reuse is affected.
+                    cx_res.isolde_amber_cache_key = None
+                    continue
+                cache_key = '{}|{}|{}'.format(
+                    ff_key, explicit_name, _residue_structural_signature(cx_res))
+                omm_res_atoms = list(omm_res.atoms())
+                cx_res_atoms = [atoms[a.index] for a in omm_res_atoms]
+                for omm_atom, cx_atom in zip(omm_res_atoms, cx_res_atoms):
+                    cx_atom.isolde_amber_type = data.atomType[omm_atom]
+                    p = data.atomParameters.get(omm_atom) or {}
+                    cx_atom.isolde_amber_params = json.dumps(p) if p else None
+                cx_res.isolde_amber_cache_key = cache_key
+
+        return self._build_system_from_data(forcefield, data, top, params)
+
+    def _build_system_from_data(self, forcefield, data, top, params):
+        '''
+        Construct the OpenMM :class:`System` from a fully-populated
+        ``_SystemData`` (``atomType``/``atomParameters`` set for every atom,
+        either from cache or from fresh template matching in
+        :meth:`_create_system`).
+
+        This is a close adaptation of the non-matching "tail" of
+        ``openmm.app.forcefield.ForceField.createSystem`` (vendored under
+        ``extern/openmm/wrappers/python/openmm/app/forcefield.py``, roughly
+        lines 1267-1423 as of the OpenMM version pinned by ``ForcefieldMgr``).
+        It is copied close to verbatim -- rather than re-derived -- because the
+        angle/proper/improper enumeration order affects floating-point
+        summation order in the resulting energy, and because the actual AMBER
+        math lives entirely in the force-generator objects
+        (``forcefield._forces``), which are called completely unmodified here.
+        If ``ForcefieldMgr._openmm_version`` is ever bumped to a version with a
+        changed ``createSystem``, re-diff this method against the new tail.
+        '''
+        import openmm as mm
+        from openmm import unit
+        from openmm.app import element as elem
+        from openmm.app.forcefield import NoCutoff, CutoffNonPeriodic, AllBonds, HAngles, HBonds
+        import itertools
+
+        nonbondedMethod = params.nonbonded_cutoff_method
+        nonbondedCutoff = params.nonbonded_cutoff_distance
+        constraints = params.rigid_bonds
+        rigidWater = params.rigid_water
+        removeCMMotion = params.remove_c_of_m_motion
+        args = {'switchDistance': None, 'flexibleConstraints': False,
+                'drudeMass': 0.4 * unit.amu}
+
+        if rigidWater is None:
+            # ISOLDE's SimParams always supplies a concrete bool; this would
+            # only trigger via direct/test misuse of this method.
+            raise ValueError('_build_system_from_data requires an explicit '
+                'rigid_water setting (True/False), not None.')
+        rigidResidue = [False] * top.getNumResidues()
+        if rigidWater:
+            for res in top.residues():
+                if res.name == 'HOH':
+                    rigidResidue[res.index] = True
+
+        # Calculate atom classes once for reuse by all generators (important
+        # for Amoeba-style forces). Present on the currently-installed OpenMM
+        # but not on the vendored extern/openmm reference copy this method is
+        # otherwise adapted from -- a reminder that the installed runtime
+        # version, not the vendored copy, is the actual source of truth to
+        # re-diff against.
+        data.setAtomClasses(forcefield)
+
+        sys = mm.System()
+        for atom in top.atoms():
+            if atom not in data.atomType:
+                raise Exception("Could not identify atom type for atom '%s'." % str(atom))
+            typename = data.atomType[atom]
+            if typename not in forcefield._atomTypes:
+                msg = "Could not find typename '%s' for atom '%s' in list of known atom types.\n" % (typename, str(atom))
+                msg += "Known atom types are: %s" % str(forcefield._atomTypes.keys())
+                raise Exception(msg)
+            mass = forcefield._atomTypes[typename].mass
+            sys.addParticle(mass)
+
+        boxVectors = top.getPeriodicBoxVectors()
+        if boxVectors is not None:
+            sys.setDefaultPeriodicBoxVectors(boxVectors[0], boxVectors[1], boxVectors[2])
+        elif nonbondedMethod not in (NoCutoff, CutoffNonPeriodic):
+            raise ValueError('Requested periodic boundary conditions for a Topology '
+                              'that does not specify periodic box dimensions')
+
+        # Make a list of all unique angles
+
+        uniqueAngles = set()
+        for bond in data.bonds:
+            for atom in data.bondedToAtom[bond.atom1]:
+                if atom != bond.atom2:
+                    if atom < bond.atom2:
+                        uniqueAngles.add((atom, bond.atom1, bond.atom2))
+                    else:
+                        uniqueAngles.add((bond.atom2, bond.atom1, atom))
+            for atom in data.bondedToAtom[bond.atom2]:
+                if atom != bond.atom1:
+                    if atom > bond.atom1:
+                        uniqueAngles.add((bond.atom1, bond.atom2, atom))
+                    else:
+                        uniqueAngles.add((atom, bond.atom2, bond.atom1))
+        data.angles = sorted(list(uniqueAngles))
+
+        # Make a list of all unique proper torsions
+
+        uniquePropers = set()
+        for angle in data.angles:
+            for atom in data.bondedToAtom[angle[0]]:
+                if atom not in angle:
+                    if atom < angle[2]:
+                        uniquePropers.add((atom, angle[0], angle[1], angle[2]))
+                    else:
+                        uniquePropers.add((angle[2], angle[1], angle[0], atom))
+            for atom in data.bondedToAtom[angle[2]]:
+                if atom not in angle:
+                    if atom > angle[0]:
+                        uniquePropers.add((angle[0], angle[1], angle[2], atom))
+                    else:
+                        uniquePropers.add((atom, angle[2], angle[1], angle[0]))
+        data.propers = sorted(list(uniquePropers))
+
+        # Make a list of all unique improper torsions
+
+        for atom in range(len(data.bondedToAtom)):
+            bondedTo = data.bondedToAtom[atom]
+            if len(bondedTo) > 2:
+                for subset in itertools.combinations(bondedTo, 3):
+                    data.impropers.append((atom, subset[0], subset[1], subset[2]))
+
+        # Identify bonds that should be implemented with constraints
+
+        if constraints == AllBonds or constraints == HAngles:
+            for bond in data.bonds:
+                bond.isConstrained = True
+        elif constraints == HBonds:
+            for bond in data.bonds:
+                atom1 = data.atoms[bond.atom1]
+                atom2 = data.atoms[bond.atom2]
+                bond.isConstrained = atom1.element is elem.hydrogen or atom2.element is elem.hydrogen
+        for bond in data.bonds:
+            atom1 = data.atoms[bond.atom1]
+            atom2 = data.atoms[bond.atom2]
+            if rigidResidue[atom1.residue.index] and rigidResidue[atom2.residue.index]:
+                bond.isConstrained = True
+
+        # Identify angles that should be implemented with constraints
+
+        if constraints == HAngles:
+            for angle in data.angles:
+                atom1 = data.atoms[angle[0]]
+                atom2 = data.atoms[angle[1]]
+                atom3 = data.atoms[angle[2]]
+                numH = 0
+                if atom1.element is elem.hydrogen:
+                    numH += 1
+                if atom3.element is elem.hydrogen:
+                    numH += 1
+                data.isAngleConstrained.append(numH == 2 or (numH == 1 and atom2.element is elem.oxygen))
+        else:
+            data.isAngleConstrained = len(data.angles) * [False]
+        for i in range(len(data.angles)):
+            angle = data.angles[i]
+            atom1 = data.atoms[angle[0]]
+            atom2 = data.atoms[angle[1]]
+            atom3 = data.atoms[angle[2]]
+            if (rigidResidue[atom1.residue.index] and rigidResidue[atom2.residue.index]
+                    and rigidResidue[atom3.residue.index]):
+                data.isAngleConstrained[i] = True
+
+        # Add virtual sites
+
+        for atom in data.virtualSites:
+            (site, site_atoms, excludeWith) = data.virtualSites[atom]
+            index = atom.index
+            data.excludeAtomWith[excludeWith].append(index)
+            if site.type == 'average2':
+                sys.setVirtualSite(index, mm.TwoParticleAverageSite(site_atoms[0], site_atoms[1], site.weights[0], site.weights[1]))
+            elif site.type == 'average3':
+                sys.setVirtualSite(index, mm.ThreeParticleAverageSite(site_atoms[0], site_atoms[1], site_atoms[2], site.weights[0], site.weights[1], site.weights[2]))
+            elif site.type == 'outOfPlane':
+                sys.setVirtualSite(index, mm.OutOfPlaneSite(site_atoms[0], site_atoms[1], site_atoms[2], site.weights[0], site.weights[1], site.weights[2]))
+            elif site.type == 'localCoords':
+                sys.setVirtualSite(index, mm.LocalCoordinatesSite(site_atoms, site.originWeights, site.xWeights, site.yWeights, site.localPos))
+
+        # Add forces to the System
+
+        for force in forcefield._forces:
+            force.createForce(sys, data, nonbondedMethod, nonbondedCutoff, args)
+        if removeCMMotion:
+            sys.addForce(mm.CMMotionRemover())
+
+        # Let force generators do postprocessing
+
+        for force in forcefield._forces:
+            if hasattr(force, 'postprocessSystem'):
+                force.postprocessSystem(sys, data, args)
+
+        # Execute scripts found in the XML files.
+
+        for script in forcefield._scripts:
+            exec(script, locals())
+
+        return sys
+
+
+# ---------------------------------------------------------------------------
+# Base class for AMBER14 + external-backend providers
+# ---------------------------------------------------------------------------
+
+class LigandBackedParameterisationProvider(ForceFieldParameterisationProvider):
+    '''
+    Base for providers that combine AMBER14 for standard residues with an
+    external backend (GARNET, Espaloma, OpenFF, …) for non-polymer ligands.
+
+    Subclasses must implement three hooks:
+
+    - :attr:`backend_forcefield_key` — the ``sim_params.forcefield`` string
+      this provider owns (e.g. ``'amber14+garnet'``).
+    - :meth:`_residue_is_eligible` — whether to send a residue to the
+      backend.  Default: any non-polymer residue with ≥ 3 heavy atoms.
+    - :meth:`_parameterise_one` — run the backend on one residue, returning
+      ``(ffxml_str, extra_dict)``.  *extra_dict* is merged into the cache
+      entry and made available to :meth:`_patch_system`.
+
+    Subclasses may override :meth:`_patch_system` (default: no-op) to
+    post-process the assembled system (e.g. replace LJ with a custom VdW).
+    '''
+
+    def __init__(self, forcefield_mgr):
+        super().__init__(forcefield_mgr)
+        # {resname: {'xml': str, **backend_extra}}
+        self._template_cache = {}
+
+    # -- abstract interface --
+
+    @property
+    def backend_forcefield_key(self):
+        raise NotImplementedError
+
+    def _residue_is_eligible(self, residue):
+        from chimerax.atomic import Residue
+        if residue.polymer_type != Residue.PT_NONE:
+            return False
+        heavy = [a for a in residue.atoms if a.element.number != 1]
+        return len(heavy) >= 3
+
+    def _parameterise_one(self, residue, logger):
+        raise NotImplementedError
+
+    def _patch_system(self, system, top):
+        pass
+
+    # -- routing --
+
+    def build_system(self, sim_construct, sim_params, logger=None):
+        if sim_params.forcefield != self.backend_forcefield_key:
+            return super().build_system(sim_construct, sim_params, logger)
+        ff  = self._forcefield_mgr['amber14']
+        ldb = self._forcefield_mgr.ligand_db('amber14')
+        return self._build_with_ligand_fallback(
+            ff, sim_construct.all_atoms, sim_construct.all_residues,
+            sim_params, ldb, logger)
+
+    # -- shared machinery --
+
+    def _build_with_ligand_fallback(self, ff, atoms, all_residues,
+                                    sim_params, ligand_db, logger):
+        '''
+        3-attempt retry loop.
+
+        0.  Stale ``isolde_template_name`` recovery.
+        1.  Backend fill-in for residues still unparameterised after
+            :meth:`_pre_parameterise_ligands`.
+        2.  Propagate error.
+        '''
+        self._pre_parameterise_ligands(all_residues, ff, logger)
+        from chimerax.isolde.openmm.openmm_interface import (
+            find_residue_templates,
+            create_openmm_topology,
+            UnparameterisedResiduesError,
+        )
+        for attempt in (0, 1, 2):
+            template_dict = find_residue_templates(
+                all_residues, ff,
+                ligand_db=ligand_db,
+                logger=logger,
+                clear_failed_overrides=True)
+            top, residue_templates = create_openmm_topology(atoms, template_dict)
+            try:
+                system = self._create_system(
+                    ff, top, sim_params, residue_templates,
+                    residues=all_residues, atoms=atoms)
+            except UnparameterisedResiduesError as e:
+                stale = [r for r in (e.unmatched + e.ambiguous)
+                         if getattr(r, 'isolde_template_name', None) is not None]
+                if attempt == 0 and stale:
+                    for r in stale:
+                        if logger is not None:
+                            logger.warning(
+                                'Residue {} was assigned template "{}" via its '
+                                'isolde_template_name override, but that template '
+                                'does not match the residue. Clearing the override '
+                                'and retrying with automatic template assignment.'
+                                .format(r, r.isolde_template_name))
+                        r.isolde_template_name = None
+                    continue
+                if attempt == 1 and e.unmatched:
+                    self._parameterise_unmatched(e.unmatched, ff, logger)
+                    continue
+                raise
+            self._patch_system(system, top)
+            return top, system
+
+    def _pre_parameterise_ligands(self, all_residues, forcefield, logger):
+        '''
+        Proactively parameterise all eligible non-polymer residues and register
+        their templates under the ``USER_`` prefix so they take precedence over
+        any AMBER14 core-XML template during the subsequent
+        ``find_residue_templates`` call.
+        '''
+        import io
+        backend = self.backend_forcefield_key.split('+')[1].upper()
+
+        for r in all_residues:
+            if not self._residue_is_eligible(r):
+                continue
+
+            name = r.name
+            existing = getattr(r, 'isolde_template_name', None)
+            if existing is not None and not existing.startswith('USER_'):
+                r.isolde_template_name = None
+
+            if name not in self._template_cache:
+                try:
+                    if logger is not None:
+                        logger.status(f'{backend}: parameterising {name}...')
+                    xml, extra = self._parameterise_one(r, logger)
+                    self._template_cache[name] = {'xml': xml, **extra}
+                    if logger is not None:
+                        logger.info(f'{backend}: parameterisation complete for {name}.')
+                except Exception as exc:
+                    if logger is not None:
+                        logger.warning(
+                            f'{backend}: could not parameterise {name} ({exc}); '
+                            f'falling back to AMBER14.')
+                    continue
+
+            forcefield.loadFile(
+                io.StringIO(self._template_cache[name]['xml']),
+                resname_prefix='USER_')
+
+    def _parameterise_unmatched(self, unmatched_residues, forcefield, logger):
+        '''
+        Parameterise still-unmatched non-polymer residues on the second retry.
+        '''
+        import io
+        from chimerax.atomic import Residue
+        backend = self.backend_forcefield_key.split('+')[1].upper()
+
+        for r in unmatched_residues:
+            if r.polymer_type != Residue.PT_NONE:
+                continue
+            name = r.name
+            if name not in self._template_cache:
+                if logger is not None:
+                    logger.status(f'{backend}: parameterising {name}...')
+                xml, extra = self._parameterise_one(r, logger)
+                self._template_cache[name] = {'xml': xml, **extra}
+                if logger is not None:
+                    logger.info(f'{backend}: parameterisation complete for {name}.')
+            forcefield.loadFile(
+                io.StringIO(self._template_cache[name]['xml']),
+                resname_prefix='USER_')
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher — routes to whichever backend owns the current forcefield key
+# ---------------------------------------------------------------------------
+
+class _DispatchingProvider(ForceFieldParameterisationProvider):
+    '''
+    Routes each ``sim_params.forcefield`` value to the appropriate
+    :class:`LigandBackedParameterisationProvider`.  Created by
+    :func:`make_parameterisation_provider` when multiple backends are installed.
+    '''
+
+    def __init__(self, forcefield_mgr, backend_providers):
+        super().__init__(forcefield_mgr)
+        self._backends = {p.backend_forcefield_key: p
+                          for p in backend_providers}
+
+    def build_system(self, sim_construct, sim_params, logger=None):
+        backend = self._backends.get(sim_params.forcefield)
+        if backend is not None:
+            return backend.build_system(sim_construct, sim_params, logger)
+        return super().build_system(sim_construct, sim_params, logger)
+
+
+def make_parameterisation_provider(forcefield_mgr):
+    '''
+    Factory — returns the most capable parameterisation provider available.
+
+    * No ML backends installed → :class:`ForceFieldParameterisationProvider`.
+    * One ML backend installed → that backend's provider directly.
+    * Multiple ML backends installed → :class:`_DispatchingProvider`.
+    '''
+    backends = []
+    if _garnet_available():
+        from .garnet_provider import GarnetParameterisationProvider
+        backends.append(GarnetParameterisationProvider(forcefield_mgr))
+    if _espaloma_available():
+        from .espaloma_provider import EspalomaParameterisationProvider
+        backends.append(EspalomaParameterisationProvider(forcefield_mgr))
+    if _espaloma_charge_available():
+        from .espaloma_charge_provider import EspalomaChargeParameterisationProvider
+        backends.append(EspalomaChargeParameterisationProvider(forcefield_mgr))
+    if _openff_available():
+        from .openff_provider import OpenFFParameterisationProvider
+        backends.append(OpenFFParameterisationProvider(forcefield_mgr))
+    if _mmff_available():
+        from .mmff_provider import MMFFParameterisationProvider
+        backends.append(MMFFParameterisationProvider(forcefield_mgr))
+
+    if not backends:
+        return ForceFieldParameterisationProvider(forcefield_mgr)
+    if len(backends) == 1:
+        return backends[0]
+    return _DispatchingProvider(forcefield_mgr, backends)

--- a/isolde/src/settings.py
+++ b/isolde/src/settings.py
@@ -18,6 +18,8 @@ class _IsoldeBasicSettings(Settings):
         'trajectory_smoothing':             defaults.TRAJECTORY_SMOOTHING,
         'smoothing_alpha':                  defaults.SMOOTHING_ALPHA,
 
+        'experience_level':                 defaults.EXPERIENCE_LEVEL,
+
         'phenix_base_path':                 None,
     }
 
@@ -62,9 +64,21 @@ class _IsoldeAdvancedSettings(Settings):
     }
 
 def register_settings_options(session):
-    from chimerax.ui.options import (
-        ColorOption, BooleanOption, IntOption, FloatOption,
+    from chimerax.ui.options import SymbolicEnumOption
+    # Symbolic names mirror ExpertModeSelector (ui/ui_base.py): the option
+    # displays the labels but stores/returns the integer level (0/1/2).
+    opt = SymbolicEnumOption(
+        'Experience level',
+        basic_settings.experience_level,
+        None,                                   # no extra callback; persistence is automatic
+        values=(0, 1, 2),
+        labels=('Default', 'Advanced', 'Developer'),
+        attr_name='experience_level',
+        settings=basic_settings,
+        balloon='Experience level applied each time ISOLDE starts. Higher '
+                'levels reveal additional advanced and developer controls.',
     )
+    session.ui.main_window.add_settings_option('ISOLDE', opt)
 
 basic_settings = None # set during bundle initialisation
 color_settings = None # set during bundle initialisation

--- a/isolde/src/tests/test_atom_deletion_robustness.py
+++ b/isolde/src/tests/test_atom_deletion_robustness.py
@@ -1,0 +1,343 @@
+# @Author: Claude
+# @Date:   01-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 01-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Robustness test for atom/residue deletion happening "under" code that holds a
+reference across time -- the hazard documented in CLAUDE.md's "Live editing:
+atoms and residues are never stable" section. ISOLDE's own editing tools, or a
+plain ChimeraX `delete` command, can remove atoms/residues at essentially any
+point in a session, including mid-simulation. A stale Python reference to a
+deleted atomic object does not reliably raise a catchable exception -- it can
+crash ChimeraX outright. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_atom_deletion_robustness.py
+
+Four scenarios, each opening its own copy of the fixture since all of them
+are destructive:
+  1. AMBER-type cache (param_provider.py): delete an atom from a residue that
+     was already cached by a prior build, then rebuild with the same
+     provider. Must not crash, must detect the residue as a fresh cache miss
+     (structural-fingerprint mismatch), and the rebuilt system's particle
+     count must match the model's new atom count.
+  2. ResidueStepper (navigate.py): delete the residue it is currently
+     tracking. `.current_residue` must fall back to None (it already guards
+     on `.deleted`) rather than dereference the deleted object, and
+     subsequent navigation must still work.
+  3. A live, running simulation: delete a mobile atom while the sim loop is
+     actively stepping. This is not something ISOLDE's GUI is known to
+     block, so it is a realistic "aggressive UI interaction" case. Either a
+     clean continuation or a caught Python exception counts as a pass; an
+     uncaught process crash would show up as this script exiting abnormally
+     with no "ALL PASS" line, rather than as a assertion failure below.
+  4. The full `Isolde.start_sim()` path (not just param_provider/SimHandler
+     directly, as scenarios 1-3 do): run a clean simulation once so the
+     AMBER-type cache is populated for the selected residue, stop it, delete
+     a backbone atom from that now-cached residue, then start again. The
+     `UnparameterisedResiduesError` this must raise is deliberately worded
+     ('Unparameterised residue detected') so `Isolde.start_sim()`'s
+     `str(e).startswith('Unparameterised')` catch fires
+     `isolde.UNPARAMETERISED_RESIDUE` -- the trigger the "Unparameterised
+     Residues" dialog/panel listens for -- instead of the raw exception
+     reaching the user as a traceback. This checks that signal fires and
+     that `start_sim()` itself doesn't raise; it can't check the actual Qt
+     dialog appearing, since that requires a running GUI this test doesn't
+     have.
+
+Prints PASS/FAIL per scenario and exits non-zero on the first assertion
+failure. Does not (and cannot) turn an actual process crash into a normal
+failure report -- that has to be read off the exit code/output of the
+ChimeraX process this script runs in.
+'''
+import os
+import time
+import numpy
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+N_MOBILE_RESIDUES = 8
+N_FIXED_RESIDUES = 6
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def _pump(session, n, stop_when=None, dt=0.02):
+    for _ in range(n):
+        session.triggers.activate_trigger('new frame', None)
+        time.sleep(dt)
+        if stop_when is not None and stop_when():
+            return True
+    return False
+
+
+def _open_fixture(session):
+    from chimerax.core.commands import run as run_cmd
+    return run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+
+
+def _mobile_and_fixed(m):
+    residues = m.residues
+    ordered = residues[numpy.lexsort((residues.numbers, residues.chain_ids))]
+    mobile = ordered[:N_MOBILE_RESIDUES].atoms
+    fixed = ordered[N_MOBILE_RESIDUES:N_MOBILE_RESIDUES + N_FIXED_RESIDUES].atoms
+    return mobile, fixed
+
+
+def _scenario_cache_survives_atom_deletion(session):
+    from chimerax.isolde.openmm.openmm_interface import SimConstruct, SimHandler
+    from chimerax.isolde.openmm.sim_param_mgr import SimParams
+    from chimerax.isolde.openmm.forcefields import ForcefieldMgr
+    from chimerax.isolde.openmm.param_provider import ForceFieldParameterisationProvider
+
+    m = _open_fixture(session)
+    try:
+        provider = ForceFieldParameterisationProvider(ForcefieldMgr(session))
+
+        def _build():
+            mobile, fixed = _mobile_and_fixed(m)
+            construct = SimConstruct(m, mobile, fixed)
+            handler = SimHandler(session, SimParams(), construct, provider)
+            return construct, handler
+
+        construct, handler = _build()
+        stats = provider.last_build_stats
+        if stats['residues_cache_miss'] != stats['residues_total']:
+            _fail('cache: expected cold-cache build to miss every residue, got %r' % stats)
+
+        # Delete an atom from one of the residues the first build just
+        # cached -- simulates a common UI action (delete atom, alt-loc
+        # cleanup, model-building edit) happening between two simulation
+        # (re)starts on the same model.
+        target_res = max(construct.mobile_residues, key=lambda r: len(r.atoms))
+        if len(target_res.atoms) < 2:
+            _fail('cache: fixture has no mobile residue with a deletable atom')
+        doomed = target_res.atoms[-1]
+        n_atoms_before = len(m.atoms)
+        doomed.delete()
+        if len(m.atoms) != n_atoms_before - 1:
+            _fail('cache: atom deletion did not reduce the model atom count')
+
+        # Rebuild with the SAME provider. Removing any atom from a standard
+        # amino acid residue breaks its exact match against the AMBER14
+        # template it previously matched -- there is no "template minus one
+        # atom" fallback -- so the *correct* outcome here is that the edited
+        # residue is detected as a stale cache miss, genuinely re-attempted,
+        # and cleanly reported as unparameterisable via the same typed
+        # exception the slow path has always raised for this case. What we're
+        # actually checking is that this is a clean, catchable, *expected*
+        # exception -- not a crash, and not the cache silently reusing the
+        # pre-deletion type/parameters for an atom that no longer exists.
+        from chimerax.isolde.openmm.openmm_interface import UnparameterisedResiduesError
+        try:
+            construct2, handler2 = _build()
+        except UnparameterisedResiduesError as e:
+            stats2 = provider.last_build_stats
+            if stats2['residues_cache_miss'] < 1:
+                _fail('cache: residue with a deleted atom was not detected as a '
+                      'cache miss even though the rebuild correctly failed to '
+                      'reparameterise it: %r' % stats2)
+            if target_res not in (e.unmatched + e.ambiguous):
+                _fail('cache: rebuild failed, but not because of the residue we '
+                      'edited (unmatched=%r ambiguous=%r)' % (e.unmatched, e.ambiguous))
+            print('PASS: AMBER-type cache correctly treated the edited residue as '
+                  'a cache miss and re-attempted matching, which cleanly (and '
+                  'correctly) failed rather than crashing or reusing stale cached '
+                  'types for a deleted atom (%d/%d residues missed)'
+                  % (stats2['residues_cache_miss'], stats2['residues_total']))
+        else:
+            # If the fixture/deleted-atom choice ever changes such that the
+            # edited residue remains parameterisable, the cache must still
+            # have caught it as a miss and the rebuilt system must reflect
+            # the new (smaller) atom count.
+            stats2 = provider.last_build_stats
+            if stats2['residues_cache_miss'] < 1:
+                _fail('cache: residue with a deleted atom was not detected as a '
+                      'cache miss: %r' % stats2)
+            system2 = handler2._system
+            if system2.getNumParticles() != len(construct2.all_atoms):
+                _fail('cache: rebuilt system particle count %d != current atom count %d'
+                      % (system2.getNumParticles(), len(construct2.all_atoms)))
+            print('PASS: AMBER-type cache correctly invalidated (%d/%d residues missed) '
+                  'after atom deletion; rebuilt system matches the new atom count (%d)'
+                  % (stats2['residues_cache_miss'], stats2['residues_total'],
+                     system2.getNumParticles()))
+    finally:
+        session.models.close([m])
+
+
+def _scenario_stepper_survives_residue_deletion(session):
+    from chimerax.isolde.navigate import get_stepper
+
+    m = _open_fixture(session)
+    try:
+        stepper = get_stepper(m)
+        # Headless ChimeraX has no `session.ui.mouse_modes`/camera, which
+        # _new_camera_position() unconditionally touches. Stub it out so the
+        # real residue-selection logic in step_to()/incr_residue() (the thing
+        # actually under test here) still runs end to end -- this is a
+        # test-only stand-in for GUI side effects, not a change to the
+        # deletion-safety logic being exercised.
+        stepper._new_camera_position = lambda *a, **k: None
+
+        residues = m.residues
+        target = residues[len(residues) // 2]
+
+        stepper.step_to(target)
+        if stepper.current_residue is not target:
+            _fail('navigate: step_to did not set current_residue')
+
+        target.delete()
+        if stepper.current_residue is not None:
+            _fail('navigate: current_residue should be None after its residue '
+                  'was deleted, got %r' % stepper.current_residue)
+        print('PASS: ResidueStepper.current_residue returns None (not a crash) '
+              'after its tracked residue is deleted')
+
+        # incr_residue()'s cr.deleted guard must let navigation recover
+        # instead of dereferencing the deleted residue.
+        nr = stepper.next_residue(polymeric_only=False)
+        if nr is None or nr.deleted:
+            _fail('navigate: next_residue after deletion returned nothing usable')
+        print('PASS: next_residue() after its tracked residue was deleted falls '
+              'back cleanly (now at %s)' % nr)
+    finally:
+        session.models.close([m])
+
+
+def _scenario_live_sim_survives_mobile_atom_deletion(session):
+    from chimerax.isolde.openmm import openmm_interface, sim_param_mgr
+    from chimerax.isolde.openmm.forcefields import ForcefieldMgr
+    from chimerax.isolde.openmm.param_provider import ForceFieldParameterisationProvider
+
+    m = _open_fixture(session)
+    handler = None
+    try:
+        mobile, fixed = _mobile_and_fixed(m)
+        construct = openmm_interface.SimConstruct(m, mobile, fixed)
+        params = sim_param_mgr.SimParams()
+        try:
+            params.set_param('platform', 'CPU')
+        except Exception:
+            params.platform = 'CPU'
+        handler = openmm_interface.SimHandler(session, params, construct,
+                                              ForceFieldParameterisationProvider(ForcefieldMgr(session)))
+        handler.start_sim()
+        _pump(session, 100)
+        if not handler.sim_running:
+            _fail('live-deletion: simulation did not start')
+
+        # Delete a mobile atom while the sim loop is actively stepping.
+        # ISOLDE is not known to block plain atom deletion while a
+        # simulation is running, so this is a realistic "user did something
+        # aggressive" case, not a contrived one.
+        mobile_atoms = construct.mobile_atoms
+        hydrogens = mobile_atoms[mobile_atoms.element_names == 'H']
+        doomed_atom = hydrogens[0] if len(hydrogens) else mobile_atoms[-1]
+
+        try:
+            doomed_atom.delete()
+            _pump(session, 100)
+            handler.stop()
+            _pump(session, 100, stop_when=lambda: not handler.sim_running)
+            print('PASS: deleting a mobile atom mid-simulation did not raise, '
+                  'and the simulation still stopped cleanly (sim_running=%r)'
+                  % handler.sim_running)
+        except Exception as e:
+            print('PASS: deleting a mobile atom mid-simulation raised a catchable '
+                  'Python exception rather than crashing the process: %r' % e)
+    finally:
+        try:
+            if handler is not None and handler.sim_running:
+                handler.stop()
+                _pump(session, 100, stop_when=lambda: not handler.sim_running)
+        except Exception:
+            pass
+        session.models.close([m])
+
+
+def _scenario_start_sim_fires_unparameterised_trigger(session):
+    from chimerax.isolde.isolde import Isolde
+
+    m = _open_fixture(session)
+    isolde = None
+    try:
+        isolde = Isolde(session)
+        isolde.selected_model = m
+
+        residues = m.residues
+        ordered = residues[numpy.lexsort((residues.numbers, residues.chain_ids))]
+        target_res = ordered[N_MOBILE_RESIDUES // 2]
+
+        fired = []
+        isolde.triggers.add_handler(
+            isolde.UNPARAMETERISED_RESIDUE, lambda *a: fired.append(True))
+
+        m.atoms.selected = False
+        target_res.atoms.selected = True
+        isolde.start_sim()
+        if not isolde.simulation_running:
+            _fail('start_sim: first (clean) start did not begin a simulation')
+        if fired:
+            _fail('start_sim: unparameterised-residue trigger fired on a clean model')
+        _pump(session, 100)
+        isolde.discard_sim()
+        _pump(session, 200, stop_when=lambda: not isolde.simulation_running)
+        if isolde.simulation_running:
+            _fail('start_sim: simulation did not stop cleanly after the first run')
+
+        # Delete a backbone atom from the residue that was just cached --
+        # breaks its match against the AMBER14 template it was cached under.
+        # The *same* Isolde instance (and therefore the same param_provider)
+        # is reused for the next start_sim(), exactly reproducing "a residue
+        # became unparameterisable between two simulation starts in one
+        # session" -- the case the AMBER-type cache exists to handle safely.
+        n_before = len(target_res.atoms)
+        target_res.atoms[-1].delete()
+        if len(target_res.atoms) != n_before - 1:
+            _fail('start_sim: atom deletion setup did not take effect')
+
+        m.atoms.selected = False
+        target_res.atoms.selected = True
+        isolde.start_sim()
+        if isolde.simulation_running:
+            _fail('start_sim: simulation should not have started for a residue '
+                  'that lost a backbone atom')
+        if not fired:
+            _fail('start_sim: UNPARAMETERISED_RESIDUE trigger did not fire after '
+                  'a cached residue became unparameterisable -- the '
+                  '"Unparameterised Residues" dialog would not have appeared')
+        print('PASS: Isolde.start_sim() caught the deleted-atom residue via the '
+              'AMBER-type cache and fired UNPARAMETERISED_RESIDUE (the signal the '
+              'warning dialog/panel listens for) instead of raising or silently '
+              'proceeding with stale cached data')
+    finally:
+        try:
+            if isolde is not None and isolde.simulation_running:
+                isolde.discard_sim()
+                _pump(session, 200, stop_when=lambda: not isolde.simulation_running)
+        except Exception:
+            pass
+        session.models.close([m])
+
+
+def run(session):
+    _scenario_cache_survives_atom_deletion(session)
+    _scenario_stepper_survives_residue_deletion(session)
+    _scenario_live_sim_survives_mobile_atom_deletion(session)
+    _scenario_start_sim_fires_unparameterised_trigger(session)
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_mmff_parameterisation.py
+++ b/isolde/src/tests/test_mmff_parameterisation.py
@@ -1,0 +1,178 @@
+# @Author: Claude
+# @Date:   03-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 03-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Regression test for the MMFF94 parameter extraction shared by the
+``amber14+mmff`` and ``amber14+espaloma-charge`` backends
+(``mmff_provider.py`` / ``espaloma_charge_provider.py``).  Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_mmff_parameterisation.py
+
+RDKit's ``MMFFMolProperties`` exposes the per-term getters as *methods on the
+properties object* (``props.GetMMFFBondStretchParams(mol, i, j)``), returning the
+*raw* MMFF94 parameters: ``(bondType, kb, r0)`` with ``kb`` in md/Å, and
+``(angleType, ka, theta0)`` with ``ka`` in md·Å/rad².  Two failure modes this
+guards against, both of which produce a valid-looking XML and a clean run while
+being physically wrong:
+
+  1. Calling the getters as free functions in ``rdForceFieldHelpers`` (they are
+     not there) or reading the wrong tuple index (element 0 is the *type*, not
+     the force constant).
+  2. Omitting the md->kcal conversion constant (143.9325 kcal·mol⁻¹ per md·Å):
+     every bond and angle then comes out ~144x too weak, so the ligand is
+     effectively unbonded and drifts apart in simulation with no traceback.
+
+The test builds ethanol as an in-memory ChimeraX structure (no fixture file),
+runs it through the *real* provider code, and asserts (a) the C-C bond force
+constant lands at AMBER scale (~256,000 kJ/mol/nm², not ~1,800), and (b) OpenMM
+loads the generated ForceField XML and builds a system with finite energy.
+
+Prints PASS/FAIL per check and exits non-zero on the first failure.  A pure
+unit test (rdkit + openmm only): it does not need espaloma-charge/DGL installed,
+because the espaloma-charge provider's bonded/units logic is exercised directly
+via ``_esc_system_to_ffxml`` with dummy charges.
+'''
+import io
+import math
+import xml.etree.ElementTree as ET
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def _build_ethanol(session):
+    '''Create an in-memory ethanol AtomicStructure (residue 'LIG') with explicit
+    hydrogens and a sensible 3D conformation.  Atom order matches the RDKit mol
+    that ``_cx_residue_to_rdmol`` will rebuild from it.'''
+    from chimerax.atomic import AtomicStructure
+    from chimerax.atomic.struct_edit import add_bond
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+
+    rd = Chem.AddHs(Chem.MolFromSmiles('CCO'))
+    AllChem.EmbedMolecule(rd, randomSeed=1)
+    AllChem.MMFFOptimizeMolecule(rd)
+    conf = rd.GetConformer()
+
+    s = AtomicStructure(session, name='ethanol-test')
+    r = s.new_residue('LIG', 'A', 1)
+    counts = {}
+    atoms = []
+    for i in range(rd.GetNumAtoms()):
+        sym = rd.GetAtomWithIdx(i).GetSymbol()
+        counts[sym] = counts.get(sym, 0) + 1
+        a = s.new_atom('%s%d' % (sym, counts[sym]), sym)
+        p = conf.GetAtomPosition(i)
+        a.coord = (p.x, p.y, p.z)
+        r.add_atom(a)
+        atoms.append(a)
+    for b in rd.GetBonds():
+        add_bond(atoms[b.GetBeginAtomIdx()], atoms[b.GetEndAtomIdx()])
+    return s, r
+
+
+def _bond_k_between_elements(xml, e1, e2):
+    '''Return the HarmonicBondForce k (kJ/mol/nm²) for the first bond whose two
+    atom types are elements {e1, e2}, or None.'''
+    root = ET.fromstring(xml)
+    type_elem = {t.get('name'): t.get('element') for t in root.iter('Type')}
+    bf = root.find('HarmonicBondForce')
+    if bf is None:
+        return None
+    want = sorted([e1, e2])
+    for bond in bf:
+        pair = sorted([type_elem[bond.get('type1')], type_elem[bond.get('type2')]])
+        if pair == want:
+            return float(bond.get('k'))
+    return None
+
+
+def _openmm_energy(residue, xml):
+    '''Load *xml* as an OpenMM ForceField, build a system for *residue*, and
+    return its potential energy (kJ/mol) at the residue's current coordinates.'''
+    from openmm import app, unit, Context, LangevinIntegrator, Vec3
+
+    ff = app.ForceField(io.StringIO(xml))
+    top = app.Topology()
+    ch = top.addChain()
+    ommres = top.addResidue(residue.name, ch)
+    cx_atoms = list(residue.atoms)
+    omm_atoms = []
+    for a in cx_atoms:
+        el = app.element.Element.getByAtomicNumber(a.element.number)
+        omm_atoms.append(top.addAtom(a.name, el, ommres))
+    idx = {a: i for i, a in enumerate(cx_atoms)}
+    b0, b1 = residue.atoms.intra_bonds.atoms
+    for x, y in zip(b0, b1):
+        top.addBond(omm_atoms[idx[x]], omm_atoms[idx[y]])
+
+    system = ff.createSystem(top, nonbondedMethod=app.NoCutoff, constraints=None)
+    positions = [Vec3(float(a.coord[0]) * 0.1, float(a.coord[1]) * 0.1,
+                      float(a.coord[2]) * 0.1) for a in cx_atoms]
+    integ = LangevinIntegrator(300 * unit.kelvin, 1 / unit.picosecond,
+                               0.001 * unit.picosecond)
+    ctx = Context(system, integ)
+    ctx.setPositions(positions * unit.nanometer)
+    return ctx.getState(getEnergy=True).getPotentialEnergy().value_in_unit(
+        unit.kilojoule_per_mole)
+
+
+def _check_provider(session, label, make_xml):
+    '''Shared assertions for one provider's generated XML.'''
+    s, r = _build_ethanol(session)
+    try:
+        xml = make_xml(r)
+        cc_k = _bond_k_between_elements(xml, 'C', 'C')
+        if cc_k is None:
+            _fail('%s: no C-C bond found in generated XML' % label)
+        # Buggy (missing md->kcal factor) gives ~1,782; correct is ~256,000.
+        if not (150_000 < cc_k < 400_000):
+            _fail('%s: C-C bond k=%.0f kJ/mol/nm^2 outside physical range '
+                  '[150k, 400k]; likely a units regression (missing the '
+                  '143.9325 md->kcal factor gives ~1,782)' % (label, cc_k))
+        energy = _openmm_energy(r, xml)
+        if not math.isfinite(energy):
+            _fail('%s: OpenMM system energy is not finite' % label)
+        print('PASS: %s -> C-C bond k=%.0f kJ/mol/nm^2 (AMBER scale), '
+              'OpenMM system built, energy=%.2f kJ/mol' % (label, cc_k, energy))
+    finally:
+        session.models.close([s])
+
+
+def _mmff_xml(residue):
+    from chimerax.isolde.openmm.mmff_provider import _mmff_parameterise_residue
+    return _mmff_parameterise_residue(residue, None)
+
+
+def _esc_xml(residue):
+    # Exercise the espaloma-charge provider's bonded/units logic without needing
+    # espaloma-charge/DGL: build the mol as the provider does, then call
+    # _esc_system_to_ffxml directly with dummy (zero) charges.
+    from rdkit.Chem import AllChem
+    from chimerax.isolde.openmm.mmff_provider import _cx_residue_to_rdmol
+    from chimerax.isolde.openmm.espaloma_charge_provider import _esc_system_to_ffxml
+    mol = _cx_residue_to_rdmol(residue)
+    AllChem.MMFFOptimizeMolecule(mol, maxIters=200)
+    charges = [0.0] * mol.GetNumAtoms()
+    return _esc_system_to_ffxml(residue, mol, charges)
+
+
+def run(session):
+    _check_provider(session, 'amber14+mmff', _mmff_xml)
+    _check_provider(session, 'amber14+espaloma-charge (bonded/units)', _esc_xml)
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_perception.py
+++ b/isolde/src/tests/test_perception.py
@@ -1,0 +1,75 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test for ISOLDE's existing chemical-perception helpers --
+comparing modelled residues against templates, and building a connectivity graph
+from a residue. The future ML parameterisation layer leans on perception of
+exactly this kind. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_perception.py
+
+Asserts the CURRENT behaviour for the bundled 1pmx fixture. Prints PASS/FAIL and
+exits non-zero on failure.
+'''
+import os
+import numpy
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+# Baseline captured 2026-06: every residue in 1pmx matches its template.
+EXPECTED_INCORRECT_COUNT = 0
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    try:
+        # --- template comparison ------------------------------------------
+        from chimerax.isolde.atomic.template_utils import (
+            find_incorrect_residues, residue_graph)
+        questionable = find_incorrect_residues(session, m, heavy_atoms_only=True)
+        if len(questionable) != EXPECTED_INCORRECT_COUNT:
+            labels = ['%s %s%d' % (r.name, r.chain_id, r.number) for r in questionable]
+            _fail('find_incorrect_residues changed: expected %d, got %d %r'
+                  % (EXPECTED_INCORRECT_COUNT, len(questionable), labels))
+        print('PASS: find_incorrect_residues flags %d residues (baseline)'
+              % len(questionable))
+
+        # --- perceived connectivity graph ---------------------------------
+        # mcsplit.Graph: one node per atom, labels = element numbers, symmetric
+        # adjacency for the intra-residue bonds.
+        r = max(m.residues, key=lambda r: len(r.atoms))
+        g = residue_graph(r, label='element')
+        if g.n != len(r.atoms):
+            _fail('residue_graph node count %d != atom count %d' % (g.n, len(r.atoms)))
+        if not numpy.array_equal(numpy.asarray(g.labels), r.atoms.elements.numbers):
+            _fail('residue_graph labels do not match atom element numbers')
+        n_edges = int(numpy.asarray(g.adjacency_matrix).sum() // 2)
+        if n_edges != len(r.atoms.intra_bonds):
+            _fail('residue_graph edge count %d != intra-bond count %d'
+                  % (n_edges, len(r.atoms.intra_bonds)))
+        print('PASS: residue_graph(%s) faithfully encodes %d atoms / %d bonds'
+              % (r.name, g.n, n_edges))
+    finally:
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_simulation.py
+++ b/isolde/src/tests/test_simulation.py
@@ -70,10 +70,14 @@ class SimTester:
 
 
         from ..openmm import openmm_interface, sim_param_mgr
-        sim_construct = self.sim_construct = openmm_interface.SimConstruct(model, all_sim_atoms, mobile_atoms, fixed_atoms)
+        sim_construct = self.sim_construct = openmm_interface.SimConstruct(model, mobile_atoms, fixed_atoms)
         sim_params = self.params = sim_param_mgr.SimParams()
 
-        sim_handler = self.sim_handler = openmm_interface.SimHandler(session, sim_params, sim_construct)
+        from ..openmm.forcefields import ForcefieldMgr
+        from ..openmm.param_provider import ForceFieldParameterisationProvider
+        forcefield_mgr = self.forcefield_mgr = ForcefieldMgr(session)
+        param_provider = ForceFieldParameterisationProvider(forcefield_mgr)
+        sim_handler = self.sim_handler = openmm_interface.SimHandler(session, sim_params, sim_construct, param_provider)
 
         sim_handler.initialize_restraint_forces()
 

--- a/isolde/src/tests/test_simulation_smoke.py
+++ b/isolde/src/tests/test_simulation_smoke.py
@@ -1,0 +1,120 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+End-to-end smoke test: ISOLDE can build a simulation System, run a few
+minimisation/equilibration rounds with restraints attached, and stop cleanly.
+Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_simulation_smoke.py
+
+Asserts the durable behavioural contract -- "model in -> running, stoppable
+simulation out" -- that the future ML-forcefield rewrite must preserve. It does
+NOT pin energies/coordinates (Langevin dynamics is stochastic); it only checks
+the machine turns over. Headless has no render loop, so it pumps the engine's
+'new frame' trigger by hand. Forces the CPU platform for determinism. Prints
+PASS/FAIL and exits non-zero on failure.
+'''
+import os
+import time
+import numpy
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+N_MOBILE_RESIDUES = 8
+N_FIXED_RESIDUES = 6
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def _pump(session, n, stop_when=None, dt=0.02):
+    for _ in range(n):
+        session.triggers.activate_trigger('new frame', None)
+        time.sleep(dt)
+        if stop_when is not None and stop_when():
+            return True
+    return False
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    from chimerax.isolde import session_extensions as sx
+    from chimerax.isolde.openmm import openmm_interface, sim_param_mgr
+    from chimerax.isolde.openmm.forcefields import ForcefieldMgr
+
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    handler = None
+    try:
+        residues = m.residues
+        ordered = residues[numpy.lexsort((residues.numbers, residues.chain_ids))]
+        mobile = ordered[:N_MOBILE_RESIDUES].atoms
+        fixed = ordered[N_MOBILE_RESIDUES:N_MOBILE_RESIDUES + N_FIXED_RESIDUES].atoms
+
+        construct = openmm_interface.SimConstruct(m, mobile, fixed)
+        params = sim_param_mgr.SimParams()
+        try:
+            params.set_param('platform', 'CPU')
+        except Exception:
+            params.platform = 'CPU'
+        from chimerax.isolde.openmm.param_provider import ForceFieldParameterisationProvider
+        handler = openmm_interface.SimHandler(session, params, construct,
+                                              ForceFieldParameterisationProvider(ForcefieldMgr(session)))
+
+        # Exercise the restraint-force wiring too: position-restrain the mobile
+        # heavy atoms (a core feature the rewrite must keep working).
+        handler.initialize_restraint_forces()
+        pr_mgr = sx.get_position_restraint_mgr(m)
+        prs = pr_mgr.add_restraints(construct.mobile_atoms)
+        prs.targets = prs.atoms.coords
+        prs.spring_constants = 1000.0
+        prs.enableds = True
+        handler.add_position_restraints(prs)
+
+        updates = [0]
+        handler.triggers.add_handler(
+            'coord update', lambda *a: updates.__setitem__(0, updates[0] + 1))
+        start_coords = m.atoms.coords.copy()
+
+        handler.start_sim()
+        _pump(session, 800, stop_when=lambda: updates[0] >= 5)
+        if not handler.sim_running:
+            _fail('simulation did not start / stay running')
+        if updates[0] < 5:
+            _fail('sim loop did not advance (only %d coord updates)' % updates[0])
+        moved = float(numpy.abs(m.atoms.coords - start_coords).max())
+        if moved <= 1e-3:
+            _fail('no atom moved -- dynamics not actually running')
+        print('PASS: simulation started and advanced (%d coord updates, max move %.3f A)'
+              % (updates[0], moved))
+
+        handler.stop()
+        _pump(session, 300, stop_when=lambda: not handler.sim_running)
+        if handler.sim_running:
+            _fail('simulation did not stop cleanly')
+        print('PASS: simulation stopped cleanly')
+    finally:
+        try:
+            if handler is not None and handler.sim_running:
+                handler.stop()
+                _pump(session, 200, stop_when=lambda: not handler.sim_running)
+        except Exception:
+            pass
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_system_build.py
+++ b/isolde/src/tests/test_system_build.py
@@ -1,0 +1,161 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test for the OpenMM ``System`` ISOLDE builds from forcefield
+templates -- the equivalence baseline the future "direct System build" must
+reproduce. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_system_build.py
+
+Builds a small SimConstruct + SimHandler (no simulation start), then checks the
+force-group layout, particle/term counts, fixed-atom masses, the nonbonded
+charge, and a single-point energy on the deterministic Reference platform
+against captured baselines. Prints PASS/FAIL and exits non-zero on failure.
+'''
+import os
+import numpy
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+N_MOBILE_RESIDUES = 8
+N_FIXED_RESIDUES = 6
+
+# Baseline captured 2026-06 (amber14 + bundled XMLs, Reference platform).
+EXPECTED_FORCE_COUNTS = {
+    'HarmonicBondForce': 1, 'HarmonicAngleForce': 1,
+    'PeriodicTorsionForce': 1, 'NonbondedForce': 1,
+}
+EXPECTED_FORCE_GROUPS = {
+    'HarmonicBondForce': 1, 'HarmonicAngleForce': 2,
+    'PeriodicTorsionForce': 3, 'NonbondedForce': 0,
+}
+EXPECTED_NUM_PARTICLES = 189
+EXPECTED_TOTAL_CHARGE = -2.0
+EXPECTED_ENERGY_KJ_MOL = 1359.25532406659
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def _build_handler(session, m, provider):
+    from chimerax.isolde.openmm.openmm_interface import SimConstruct, SimHandler
+    from chimerax.isolde.openmm.sim_param_mgr import SimParams
+    residues = m.residues
+    ordered = residues[numpy.lexsort((residues.numbers, residues.chain_ids))]
+    mobile = ordered[:N_MOBILE_RESIDUES].atoms
+    fixed = ordered[N_MOBILE_RESIDUES:N_MOBILE_RESIDUES + N_FIXED_RESIDUES].atoms
+    construct = SimConstruct(m, mobile, fixed)
+    handler = SimHandler(session, SimParams(), construct, provider)
+    return construct, handler
+
+
+def _check_baseline(system, construct, label):
+    import openmm
+    from openmm import unit
+
+    # --- particle count + mobile/fixed mass partition -----------------
+    all_atoms = construct.all_atoms
+    if system.getNumParticles() != len(all_atoms):
+        _fail('%s: particle count %d != atom count %d'
+              % (label, system.getNumParticles(), len(all_atoms)))
+    fixed_idx = set(all_atoms.indices(construct.fixed_atoms).tolist())
+    for i in range(system.getNumParticles()):
+        mass = system.getParticleMass(i).value_in_unit(unit.dalton)
+        if i in fixed_idx and mass != 0:
+            _fail('%s: fixed particle %d not pinned (mass %r)' % (label, i, mass))
+        if i not in fixed_idx and mass <= 0:
+            _fail('%s: mobile particle %d lost its mass' % (label, i))
+    print('PASS (%s): %d particles; fixed atoms pinned, mobile atoms massive'
+          % (label, system.getNumParticles()))
+
+    # --- force-group layout + term counts -----------------------------
+    force_counts, force_groups = {}, {}
+    for f in system.getForces():
+        name = type(f).__name__
+        force_counts[name] = force_counts.get(name, 0) + 1
+        force_groups[name] = f.getForceGroup()
+    if force_counts != EXPECTED_FORCE_COUNTS:
+        _fail('%s: force counts changed: %r' % (label, force_counts))
+    if force_groups != EXPECTED_FORCE_GROUPS:
+        _fail('%s: force-group layout changed: %r' % (label, force_groups))
+    if system.getNumParticles() != EXPECTED_NUM_PARTICLES:
+        _fail('%s: num particles %d != baseline %d'
+              % (label, system.getNumParticles(), EXPECTED_NUM_PARTICLES))
+    print('PASS (%s): force counts + group layout match baseline' % label)
+
+    # --- nonbonded charge + single-point energy (Reference platform) --
+    total_charge = 0.0
+    for f in system.getForces():
+        if isinstance(f, openmm.NonbondedForce):
+            for i in range(f.getNumParticles()):
+                q, sigma, eps = f.getParticleParameters(i)
+                total_charge += q.value_in_unit(unit.elementary_charge)
+            break
+    if abs(round(total_charge, 4) - EXPECTED_TOTAL_CHARGE) > 1e-3:
+        _fail('%s: total charge %r != baseline %r'
+              % (label, round(total_charge, 4), EXPECTED_TOTAL_CHARGE))
+
+    box = 50.0 * unit.nanometer
+    system.setDefaultPeriodicBoxVectors(
+        openmm.Vec3(box, 0, 0), openmm.Vec3(0, box, 0), openmm.Vec3(0, 0, box))
+    platform = openmm.Platform.getPlatformByName('Reference')
+    context = openmm.Context(system, openmm.VerletIntegrator(1.0 * unit.femtoseconds),
+                             platform)
+    context.setPositions((construct.all_atoms.coords / 10.0) * unit.nanometer)
+    energy = context.getState(getEnergy=True).getPotentialEnergy().value_in_unit(
+        unit.kilojoule_per_mole)
+    del context
+    tol = 1.0 + 1e-3 * abs(EXPECTED_ENERGY_KJ_MOL)
+    if abs(energy - EXPECTED_ENERGY_KJ_MOL) > tol:
+        _fail('%s: single-point energy %.4f != baseline %.4f (tol %.2f)'
+              % (label, energy, EXPECTED_ENERGY_KJ_MOL, tol))
+    print('PASS (%s): total charge %.1f and single-point energy %.1f kJ/mol match baseline'
+          % (label, total_charge, energy))
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    from chimerax.isolde.openmm.forcefields import ForcefieldMgr
+    from chimerax.isolde.openmm.param_provider import ForceFieldParameterisationProvider
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    try:
+        provider = ForceFieldParameterisationProvider(ForcefieldMgr(session))
+
+        # --- first build: cold cache, every residue must be a cache miss --
+        construct, handler = _build_handler(session, m, provider)
+        _check_baseline(handler._system, construct, 'cold cache')
+        stats = provider.last_build_stats
+        if stats['residues_cache_miss'] != stats['residues_total']:
+            _fail('cold-cache build: expected every residue to miss, got %r' % stats)
+        print('PASS: cold-cache build resolved all %d residues via template matching'
+              % stats['residues_total'])
+
+        # --- second build: warm cache, every residue must be a cache hit,
+        #     and the resulting system must reproduce the same baseline -----
+        construct2, handler2 = _build_handler(session, m, provider)
+        stats2 = provider.last_build_stats
+        if stats2['residues_cache_miss'] != 0 or stats2['residues_cache_hit'] != stats2['residues_total']:
+            _fail('warm-cache build: expected every residue to hit, got %r' % stats2)
+        print('PASS: warm-cache build resolved all %d residues from cache (0 misses)'
+              % stats2['residues_total'])
+        _check_baseline(handler2._system, construct2, 'warm cache')
+    finally:
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_template_resolution.py
+++ b/isolde/src/tests/test_template_resolution.py
@@ -1,0 +1,120 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test for ISOLDE's forcefield-template resolution -- the path
+the future ML parameterisation backend will replace. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_template_resolution.py
+
+Driven through the read-only ``isolde preflight parameters`` dry-run (resolves
+templates without building an OpenMM Context). Asserts the CURRENT behaviour for
+the bundled 1pmx fixture against captured baselines, so a future change that
+alters template assignment fails loudly. Prints PASS/FAIL lines and exits
+non-zero on failure so it can gate a build.
+'''
+import os
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+# Baseline captured 2026-06 against amber14 + the bundled forcefield XMLs.
+EXPECTED_COUNTS = {
+    'n_total': 70, 'n_matched': 70, 'n_ambiguous': 0, 'n_unmatched': 0,
+    'ready_for_simulation': True,
+}
+# find_residue_templates only assigns explicit templates to the cysteines (all
+# disulfide-bonded -> CYX); standard residues are left to OpenMM's matcher.
+EXPECTED_TEMPLATE_MAP = {
+    '/A CYS 6': 'CYX', '/A CYS 18': 'CYX', '/A CYS 47': 'CYX',
+    '/A CYS 48': 'CYX', '/A CYS 52': 'CYX', '/A CYS 61': 'CYX',
+}
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    try:
+        from chimerax.isolde.validation.cmd import isolde_preflight_parameters
+
+        # --- preflight dict shape + per-class counts -----------------------
+        result = isolde_preflight_parameters(session, model=m, forcefield=None)
+        for key in ('model', 'forcefield', 'n_total', 'n_matched', 'n_ambiguous',
+                    'n_unmatched', 'ready_for_simulation', 'unmatched', 'ambiguous'):
+            if key not in result:
+                _fail('preflight result lost key %r' % key)
+        if (result['n_matched'] + result['n_ambiguous'] + result['n_unmatched']
+                != result['n_total']):
+            _fail('preflight counts do not sum to n_total: %r' % result)
+        for key, expect in EXPECTED_COUNTS.items():
+            if result[key] != expect:
+                _fail('preflight %s: expected %r, got %r' % (key, expect, result[key]))
+        print('PASS: preflight counts match baseline (%d residues, all matched)'
+              % result['n_total'])
+
+        # --- explicit per-residue template assignment ----------------------
+        from chimerax.atomic import Residues
+        from chimerax.isolde.validation.cmd import _get_forcefield
+        from chimerax.isolde.openmm.openmm_interface import find_residue_templates
+        ff, ligand_db, ff_name = _get_forcefield(session, None)
+        residues = Residues(sorted(m.residues,
+            key=lambda r: (r.chain_id, r.number, r.insertion_code)))
+        tdict = find_residue_templates(residues, ff, ligand_db=ligand_db,
+            logger=session.logger)
+        mapping = {}
+        for i, tname in tdict.items():
+            r = residues[i]
+            mapping['/{} {} {}'.format(r.chain_id, r.name, r.number)] = tname
+        if mapping != EXPECTED_TEMPLATE_MAP:
+            _fail('template map changed.\n  expected %r\n  got      %r'
+                  % (EXPECTED_TEMPLATE_MAP, mapping))
+        print('PASS: per-residue template map matches baseline (%d explicit)'
+              % len(mapping))
+
+        # --- unmatched-residue safety net ----------------------------------
+        # OpenMM's template system is the safety net today: an unrecognisable
+        # residue is flagged unmatched (the rewrite removes this net). Forcing a
+        # heavy atom to boron guarantees no template can match by name/topology.
+        from chimerax.atomic import Element
+        target = None
+        for r in m.residues:
+            heavy = r.atoms[r.atoms.element_names != 'H']
+            if len(heavy):
+                target = (r, heavy[0])
+                break
+        if target is None:
+            _fail('fixture has no heavy atoms?')
+        r, atom = target
+        atom.element = Element.get_element('B')
+        result = isolde_preflight_parameters(session, model=m, forcefield=None)
+        if result['ready_for_simulation'] is not False:
+            _fail('boron-mutated model still reported ready_for_simulation')
+        hit = [u for u in result['unmatched']
+               if u['number'] == r.number and u['chain_id'] == r.chain_id]
+        if not hit:
+            _fail('boron-mutated residue %s %s%d was not flagged unmatched'
+                  % (r.name, r.chain_id, r.number))
+        if not isinstance(hit[0]['candidates_by_name'], list):
+            _fail('unmatched residue lost its candidates_by_name list')
+        print('PASS: an unrecognisable residue is flagged unmatched with candidates')
+    finally:
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/ui/general_tab/__init__.py
+++ b/isolde/src/ui/general_tab/__init__.py
@@ -22,6 +22,8 @@ class GeneralTab(IsoldeTab):
         self.addWidget(SimFidelityPanel(session, isolde, parent, gui))
         from .nonbonded import NonBondedPanel
         self.addWidget(NonBondedPanel(session, isolde, parent, gui))
+        from .forcefield import ForceFieldPanel
+        self.addWidget(ForceFieldPanel(session, isolde, parent, gui))
         from .platform import ComputationalPlatformPanel
         self.addWidget(ComputationalPlatformPanel(session, isolde, parent, gui))
         from .mask_settings import MaskAndSpotlightSettingsPanel

--- a/isolde/src/ui/general_tab/forcefield.py
+++ b/isolde/src/ui/general_tab/forcefield.py
@@ -1,0 +1,120 @@
+# @Author: Tristan Croll
+# @Date:   01-Jul-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 01-Jul-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Forcefield-selection UI panel for the ISOLDE General tab.
+
+Appears as a collapsible panel (ADVANCED expert level) between the
+NonBonded settings and the Computational Platform panels.  The combo box
+is populated from
+:func:`chimerax.isolde.openmm.param_provider.available_parameterisation_backends`.
+
+When ``'amber14+garnet'`` is listed but GARNET cannot be imported it is
+shown greyed-out with install instructions in a tooltip.
+'''
+
+from ..ui_base import (
+    DefaultSpacerItem,
+    UI_Panel_Base,
+    DefaultHLayout,
+    ExpertModeSelector,
+)
+from ..collapse_button import CollapsibleArea
+
+from Qt.QtWidgets import QLabel, QComboBox
+
+
+class ForceFieldPanel(CollapsibleArea):
+    def __init__(self, session, isolde, parent, gui, **kwargs):
+        super().__init__(gui, parent, title='Forcefield',
+                         expert_level=ExpertModeSelector.ADVANCED, **kwargs)
+        ffd = self.content = ForceFieldDialog(session, isolde, gui, self)
+        self.setContentLayout(ffd.main_layout)
+
+
+class ForceFieldDialog(UI_Panel_Base):
+    def __init__(self, session, isolde, gui, collapse_area):
+        super().__init__(session, isolde, gui, collapse_area.content_area)
+        self.container = collapse_area
+
+        mf = self.main_frame
+        ml = self.main_layout = DefaultHLayout()
+        cb = self.combo_box = QComboBox(mf)
+        self._populate_combo_box()
+        cb.currentIndexChanged.connect(self._combo_changed_cb)
+        ml.addWidget(cb)
+        ml.addItem(DefaultSpacerItem())
+
+    def _populate_combo_box(self):
+        from chimerax.isolde.openmm.param_provider import (
+            _garnet_available, _espaloma_available, _espaloma_charge_available,
+            _openff_available, _mmff_available)
+
+        sim_params = self.session.isolde.sim_params
+        cb = self.combo_box
+        cb.blockSignals(True)
+        cb.clear()
+
+        # All backends in display order; unavailable items are shown greyed-out
+        # so users know the option exists even when dependencies are absent.
+        all_backends = ['amber14', 'amber14+garnet', 'amber14+espaloma',
+                        'amber14+espaloma-charge', 'amber14+openff',
+                        'amber14+mmff', 'charmm36']
+
+        _disabled = {
+            'amber14+garnet': (not _garnet_available(),
+                'GARNET is not installed.\n'
+                'To enable, run inside ChimeraX:\n'
+                '  pip install garnetff torch torch_geometric igraph\n'
+                'then restart ChimeraX.'),
+            'amber14+espaloma': (not _espaloma_available(),
+                'Espaloma is not installed.\n'
+                'Requires conda — see the ISOLDE docs.'),
+            'amber14+espaloma-charge': (not _espaloma_charge_available(),
+                'espaloma-charge is not installed.\n'
+                'GNN charges (AM1-BCC quality) + MMFF94 bonded terms.\n'
+                'To enable, run in an admin cmd:\n'
+                '  python.exe -m pip install espaloma-charge dgl\n'
+                'then restart ChimeraX.'),
+            'amber14+openff': (not _openff_available(),
+                'OpenFF Toolkit is not installed.\n'
+                'To enable, run inside ChimeraX:\n'
+                '  pip install openff-toolkit rdkit\n'
+                'then restart ChimeraX.'),
+            'amber14+mmff': (not _mmff_available(),
+                'RDKit is not installed.\n'
+                'To enable, run in an admin cmd:\n'
+                '  python.exe -m pip install rdkit\n'
+                'then restart ChimeraX.\n'
+                '(approximate — prefer amber14+garnet for production)'),
+        }
+
+        for name in all_backends:
+            cb.addItem(name)
+            disabled_flag, tooltip = _disabled.get(name, (False, ''))
+            if disabled_flag:
+                model = cb.model()
+                item = model.item(cb.count() - 1)
+                item.setEnabled(False)
+                item.setToolTip(tooltip)
+
+        current = getattr(sim_params, 'forcefield', 'amber14')
+        idx = cb.findText(current)
+        cb.setCurrentIndex(idx if idx >= 0 else 0)
+        cb.blockSignals(False)
+
+    def _combo_changed_cb(self, *_):
+        chosen = self.combo_box.currentText()
+        from chimerax.isolde.openmm.param_provider import (
+            _garnet_available, _espaloma_available, _espaloma_charge_available,
+            _openff_available, _mmff_available)
+        if chosen == 'amber14+garnet'          and not _garnet_available():          return
+        if chosen == 'amber14+espaloma'        and not _espaloma_available():        return
+        if chosen == 'amber14+espaloma-charge' and not _espaloma_charge_available(): return
+        if chosen == 'amber14+openff'          and not _openff_available():          return
+        if chosen == 'amber14+mmff'            and not _mmff_available():            return
+        self.session.isolde.sim_params.forcefield = chosen

--- a/isolde/src/ui/main_win.py
+++ b/isolde/src/ui/main_win.py
@@ -105,6 +105,15 @@ class IsoldeMainWin(MainToolWindow):
         l1.addWidget(QLabel('Experience level: ', parent=tw))
         from .ui_base import ExpertModeSelector
         elcb = self.expert_mode_combo_box = ExpertModeSelector(tw)
+        # Initialise from the persisted startup default (Favourites > Settings >
+        # ISOLDE). Changing the combo box during a session is transient and does
+        # not write back to the setting.
+        from .. import settings
+        level = getattr(settings.basic_settings, 'experience_level',
+            ExpertModeSelector.DEFAULT)
+        idx = elcb.findData(level)
+        if idx >= 0:
+            elcb.setCurrentIndex(idx)
         l1.addWidget(elcb)
 
         self._isolde_trigger_handlers.append(session.isolde.triggers.add_handler(self.isolde.SIMULATION_STARTED, self._sim_start_cb))


### PR DESCRIPTION
## Summary

Adds a modular small-molecule / ligand parameterisation system with selectable backends, plus a self-contained "Experience level" startup setting. Split out from a larger branch; the companion **tests** PR carries the forcefield-independent test suite.

### Modular forcefield / small-molecule parameterisation

Pluggable ligand-parameterisation backends built on a common `LigandBackedParameterisationProvider` (AMBER14 for standard residues, a selectable backend for non-polymer ligands), surfaced in the **General → Forcefield** panel:

- `amber14+garnet`
- `amber14+espaloma-charge`
- `amber14+mmff`
- `amber14+espaloma` **(WIP)**
- `amber14+openff` **(WIP)**

`make_parameterisation_provider()` selects whichever providers' dependencies import and greys out the rest in the UI. Availability probes catch `Exception` (not just `ImportError`) so a native-extension mismatch cleanly disables a backend instead of crashing startup. Also speeds up simulation start by removing reliance on OpenMM's `forcefield.py` templates.

Source: `param_provider.py`, `garnet_provider.py`, `espaloma_provider.py`, `espaloma_charge_provider.py`, `mmff_provider.py`, `openff_provider.py`, `forcefields.py`, `ui/general_tab/forcefield.py`, plus a refactor of `openmm/openmm_interface.py` and provider wiring in `isolde.py` / `__init__.py`.

### Experience level startup setting

A persisted basic setting (Default / Advanced / Developer) exposed via **Favourites → Settings → ISOLDE** as a `SymbolicEnumOption`; the main-window expert-mode combo initialises from it on startup. (`constants.py`, `settings.py`, `ui/main_win.py`.)

### Tests

Parameterisation-path tests that depend on this PR's backends: `test_mmff_parameterisation`, `test_perception`, `test_system_build`, `test_template_resolution`, `test_atom_deletion_robustness`, `test_simulation`, `test_simulation_smoke`. (These import `param_provider`, so they live here rather than in the tests PR.)

## Notes / known limitations

- The rdkit-based providers infer bond orders from 3D geometry assuming a **neutral** ligand; charged species (e.g. GTP at −8) fall back to AMBER14. Documented as a known limitation.
- `amber14+espaloma` and `amber14+openff` are **WIP** — selectable but not yet validated to the standard of garnet / espaloma-charge / mmff.
