### PR TITLE
Headless test runner + forcefield-independent test suite

### DIFF
--- a/isolde/CLAUDE.md
+++ b/isolde/CLAUDE.md
@@ -33,7 +33,31 @@ The build preprocesses `pyproject.toml.in` via `prep_toml.py` before invoking th
 
 ## Testing
 
-There is one test file: `isolde/src/tests/test_simulation.py` (`SimTester` class). Tests are run manually inside ChimeraX — there is no pytest runner or CI pipeline. When making changes, load a structure in ChimeraX and exercise the affected feature interactively.
+There is no pytest runner or CI pipeline. Tests live in `isolde/src/tests/` and
+run inside ChimeraX. Two kinds:
+
+- **Self-running headless tests** follow a convention: a
+  `if session is not None: run(session)` footer (ChimeraX injects `session`
+  under `--script`), `run()` prints `ALL PASS` on success, and failures call a
+  `_fail()` helper that raises `SystemExit`. Run one directly:
+
+  ```bat
+  run_chimerax.bat --nogui --exit --script src/tests/test_mmff_parameterisation.py
+  ```
+
+  `run_tests.bat` (repo root) discovers every `src/tests/test_*.py`, runs each
+  self-running test headlessly, and reports pass/fail per file — it judges
+  success by the `ALL PASS` sentinel in the output (a `SystemExit` from a
+  ChimeraX `--script` does not reliably surface as a process exit code). Files
+  with no `ALL PASS` sentinel are skipped, not failed. Examples:
+  `test_mmff_parameterisation.py`, `test_atom_deletion_robustness.py`.
+
+- **Manual/interactive harness:** `test_simulation.py` (`SimTester` class) is
+  driven by hand inside a GUI ChimeraX session; it has no headless footer and is
+  skipped by `run_tests.bat`.
+
+When making changes, also load a structure in ChimeraX and exercise the affected
+feature interactively.
 
 **Do NOT try to test ISOLDE (or Clipper map setup) headless via `--nogui` or
 `--offscreen`.** It does not work and is not worth attempting:

--- a/isolde/run_tests.bat
+++ b/isolde/run_tests.bat
@@ -1,0 +1,77 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+REM ===========================================================================
+REM run_tests.bat -- run every self-contained ISOLDE test under src\tests\
+REM headlessly (via run_chimerax.bat) and report pass/fail per file.
+REM
+REM A "self-contained" test follows the repo convention: it runs itself when
+REM ChimeraX injects `session` (the `if session is not None: run(session)`
+REM footer) and prints "ALL PASS" on success / calls _fail() (which raises
+REM SystemExit) otherwise. See test_mmff_parameterisation.py and
+REM test_atom_deletion_robustness.py for the pattern.
+REM
+REM Files without an "ALL PASS" sentinel are SKIPPED, not failed -- e.g.
+REM test_simulation.py is the interactive SimTester harness (CLAUDE.md: "run
+REM manually inside ChimeraX"), not a headless pass/fail test. Any future test
+REM that adopts the convention is picked up automatically.
+REM
+REM Success is judged by the presence of "ALL PASS" in the captured output, not
+REM by exit code: a SystemExit raised inside a ChimeraX --script does not
+REM reliably surface as a process exit code.
+REM
+REM Usage:  run_tests.bat [release]
+REM   release -> forwarded to run_chimerax.bat to target the stable install
+REM              (omitted -> the daily build), matching run_chimerax.bat's own
+REM              argument convention.
+REM ===========================================================================
+
+set "HERE=%~dp0"
+if "%HERE:~-1%"=="\" set "HERE=%HERE:~0,-1%"
+
+set "RELEASE="
+if /i "%~1"=="release" set "RELEASE=release"
+
+set "TESTDIR=%HERE%\src\tests"
+set "OUT=%TEMP%\isolde_test_out.txt"
+set /a NPASS=0, NFAIL=0, NSKIP=0
+set "FAILED="
+
+REM run from the repo root so the forward-slash --script path resolves the same
+REM way it does when invoked by hand.
+pushd "%HERE%"
+
+echo ===========================================================================
+echo Running ISOLDE tests in %TESTDIR%
+echo ===========================================================================
+
+for %%F in ("%TESTDIR%\test_*.py") do (
+    findstr /c:"ALL PASS" "%%F" >nul 2>&1
+    if errorlevel 1 (
+        echo [SKIP] %%~nxF  ^(no "ALL PASS" sentinel: not a self-running test^)
+        set /a NSKIP+=1
+    ) else (
+        echo.
+        echo --- %%~nxF ---
+        call "%HERE%\run_chimerax.bat" !RELEASE! --nogui --exit --script "src/tests/%%~nxF" > "%OUT%" 2>&1
+        type "%OUT%"
+        findstr /c:"ALL PASS" "%OUT%" >nul 2>&1
+        if errorlevel 1 (
+            echo [FAIL] %%~nxF
+            set /a NFAIL+=1
+            set "FAILED=!FAILED! %%~nxF"
+        ) else (
+            echo [PASS] %%~nxF
+            set /a NPASS+=1
+        )
+    )
+)
+
+echo.
+echo ===========================================================================
+echo Summary: !NPASS! passed, !NFAIL! failed, !NSKIP! skipped
+if not "!FAILED!"=="" echo Failed:!FAILED!
+echo ===========================================================================
+
+popd
+if !NFAIL! gtr 0 exit /b 1
+exit /b 0

--- a/isolde/src/tests/gui_mouse_circle.py
+++ b/isolde/src/tests/gui_mouse_circle.py
@@ -1,0 +1,104 @@
+# @Author: Tristan Croll
+# @Date:   19-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 19-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+
+'''
+GUI-ONLY demo: move the mouse cursor in a circle for ~5 seconds.
+
+This is NOT a pytest test -- it needs a Qt event loop, so it cannot run under
+``--nogui``. Run it inside a normal GUI ChimeraX session:
+
+    runscript /path/to/isolde/src/tests/gui_mouse_circle.py
+
+It just drives the physical cursor (QCursor.setPos) around a circle centred on
+the ChimeraX main window. No model, simulation, or mouse mode involved.
+
+NOTE: written but NOT executed by the author (this environment is headless), so
+it has only been syntax-checked.
+'''
+
+import math
+
+DURATION_S = 5.0
+RADIUS_FRAC = 0.15       # circle radius as a fraction of the smaller window dim
+TICK_MS = 16             # ~60 cursor updates per second
+PERIOD_S = 1.25          # seconds per revolution -> ~4 revolutions in 5 s
+
+
+class MouseCircleDriver:
+    def __init__(self, session):
+        self.session = session
+        self.log = session.logger
+
+        from Qt.QtGui import QGuiApplication
+        # Centre the circle on the ChimeraX main window if we can, else on the
+        # primary screen.
+        cx = cy = radius = None
+        try:
+            mw = session.ui.main_window
+            from Qt.QtCore import QPoint
+            w, h = mw.width(), mw.height()
+            centre = mw.mapToGlobal(QPoint(w // 2, h // 2))
+            cx, cy = centre.x(), centre.y()
+            radius = RADIUS_FRAC * min(w, h)
+        except Exception:
+            geo = QGuiApplication.primaryScreen().geometry()
+            cx, cy = geo.center().x(), geo.center().y()
+            radius = RADIUS_FRAC * min(geo.width(), geo.height())
+
+        self.cx, self.cy, self.radius = cx, cy, radius
+        self.elapsed = 0.0
+        self.steps = 0
+        self.log.info('Mouse-circle: orbiting cursor for {:.0f} s '
+                      '(centre {},{}; radius {:.0f} px).'.format(
+                          DURATION_S, int(cx), int(cy), radius))
+        self._start_timer()
+
+    def _start_timer(self):
+        from Qt.QtCore import QTimer
+        # Parent to the main window so Qt keeps the timer alive after the
+        # runscript scope exits (otherwise it is garbage-collected before it
+        # ever fires).
+        parent = getattr(self.session.ui, 'main_window', None)
+        self._timer = QTimer(parent)
+        self._timer.timeout.connect(self._tick)
+        self._timer.start(TICK_MS)
+
+    def _tick(self):
+        self.elapsed += TICK_MS / 1000.0
+        if self.elapsed >= DURATION_S:
+            self._timer.stop()
+            self.log.info('Mouse-circle done: {} cursor moves over {:.1f} s.'.format(
+                self.steps, self.elapsed))
+            # Release the reference we stashed on the session.
+            if getattr(self.session, '_mouse_circle_driver', None) is self:
+                self.session._mouse_circle_driver = None
+            return
+        from Qt.QtCore import QPoint
+        from Qt.QtGui import QCursor
+        theta = 2 * math.pi * (self.elapsed / PERIOD_S)
+        x = self.cx + self.radius * math.cos(theta)
+        y = self.cy + self.radius * math.sin(theta)
+        QCursor.setPos(QPoint(int(x), int(y)))
+        self.steps += 1
+
+
+def run_mouse_circle(session):
+    if not session.ui.is_gui:
+        session.logger.warning(
+            'gui_mouse_circle requires GUI mode; it cannot run under --nogui.')
+        return None
+    # Stash on the session so the driver (and its timer) survive the runscript
+    # scope; without a persistent reference it is GC'd before the timer fires.
+    driver = MouseCircleDriver(session)
+    session._mouse_circle_driver = driver
+    return driver
+
+
+# When launched via "runscript", ChimeraX injects `session` into globals.
+if 'session' in dir():
+    run_mouse_circle(session)        # noqa: F821

--- a/isolde/src/tests/test_cmd_surface.py
+++ b/isolde/src/tests/test_cmd_surface.py
@@ -1,0 +1,72 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test for the stable edges of ISOLDE's command surface: the
+read-only ``isolde status`` report and the custom ``IsoldeStructureArg``
+argument parser. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_cmd_surface.py
+
+Prints PASS/FAIL and exits non-zero on failure.
+'''
+import os
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+
+    # --- isolde status: read-only, works before "isolde start" ------------
+    from chimerax.isolde.cmd.cmd import isolde_status
+    status = isolde_status(session)
+    for key in ('isolde_started', 'selected_model', 'simulation_running', 'forcefield'):
+        if key not in status:
+            _fail('isolde status lost key %r' % key)
+    if not isinstance(status['isolde_started'], bool):
+        _fail('isolde_started should be bool, got %r' % (status['isolde_started'],))
+    if not isinstance(status['simulation_running'], bool):
+        _fail('simulation_running should be bool, got %r' % (status['simulation_running'],))
+    print('PASS: isolde status returns the documented dict shape')
+
+    # --- IsoldeStructureArg: single-structure parse + rejection -----------
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    try:
+        from chimerax.isolde.cmd.argspec import IsoldeStructureArg
+        from chimerax.core.commands import AnnotationError
+        parsed, text, rest = IsoldeStructureArg.parse('#%s' % m.id_string, session)
+        if parsed is not m:
+            _fail('IsoldeStructureArg did not parse to the opened model')
+        print('PASS: IsoldeStructureArg parses a single structure spec')
+
+        rejected = False
+        try:
+            IsoldeStructureArg.parse('#999', session)
+        except AnnotationError:
+            rejected = True
+        if not rejected:
+            _fail('IsoldeStructureArg accepted a spec matching no structure')
+        print('PASS: IsoldeStructureArg rejects a no-match spec (AnnotationError)')
+    finally:
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_molobject_layer.py
+++ b/isolde/src/tests/test_molobject_layer.py
@@ -1,0 +1,80 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test for the C-backed molecular-object layer the future
+model-resident force-field store will build on. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_molobject_layer.py
+
+Checks the per-object <-> vectorized-Collection parity (a singular c_property
+and its plural cvec_property twin must read the same values -- the invariant new
+parameter properties, and a new Angle class, will follow), and that the custom
+attributes ISOLDE registers on core ChimeraX objects are usable. Prints PASS/FAIL
+and exits non-zero on failure.
+'''
+import os
+import numpy
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def _check_parity(collection, singular_attr, plural_attr, label):
+    if len(collection) == 0:
+        _fail('%s: no objects to compare' % label)
+    plural = numpy.asarray(getattr(collection, plural_attr))
+    singular = numpy.array([getattr(obj, singular_attr) for obj in collection])
+    if not numpy.allclose(plural, singular, equal_nan=True):
+        _fail('%s: %s (plural) != per-object %s' % (label, plural_attr, singular_attr))
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    try:
+        # --- chiral centre parity -----------------------------------------
+        from chimerax.isolde.molobject import get_chiral_mgr
+        chirals = get_chiral_mgr(session).get_chirals(m.atoms, create=True)
+        _check_parity(chirals, 'angle', 'angles', 'ChiralCenters')
+        print('PASS: ChiralCenters.angles matches per-object .angle (%d centres)'
+              % len(chirals))
+
+        # --- proper-dihedral parity ---------------------------------------
+        from chimerax.isolde.session_extensions import get_proper_dihedral_mgr
+        phis = get_proper_dihedral_mgr(session).get_dihedrals(m.residues, 'phi', create=True)
+        _check_parity(phis, 'angle', 'angles', 'ProperDihedrals')
+        print('PASS: ProperDihedrals.angles matches per-object .angle (%d phi)' % len(phis))
+
+        # --- custom-attr round-trip ---------------------------------------
+        r = m.residues[0]
+        original = getattr(r, 'isolde_ignore', False)
+        r.isolde_ignore = True
+        if r.isolde_ignore is not True:
+            _fail('Residue.isolde_ignore did not round-trip True')
+        r.isolde_ignore = bool(original)
+        m.isolde_initialized = True
+        if m.isolde_initialized is not True:
+            _fail('AtomicStructure.isolde_initialized did not round-trip True')
+        print('PASS: ISOLDE custom attributes are registered and round-trip')
+    finally:
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_session_roundtrip.py
+++ b/isolde/src/tests/test_session_roundtrip.py
@@ -1,0 +1,124 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test: ISOLDE restraints survive a ChimeraX session
+save/restore -- the persistence substrate the future model-resident
+force-field store will build on. Run inside ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_session_roundtrip.py
+
+Adds position + distance restraints, saves the session, reopens it, and checks
+the restraints are re-queryable from the restored managers with their targets /
+spring constants / enabled flags intact. Prints PASS/FAIL and exits non-zero on
+failure.
+'''
+import os
+import tempfile
+import numpy
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def _ca_atoms(m, n=5):
+    cas = m.atoms[m.atoms.names == 'CA']
+    return cas[:n]
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    from chimerax.atomic import AtomicStructure
+    from chimerax.isolde import session_extensions as sx
+    from chimerax.isolde import ISOLDE_STATE_VERSION
+
+    if not (isinstance(ISOLDE_STATE_VERSION, int) and ISOLDE_STATE_VERSION > 0):
+        _fail('ISOLDE_STATE_VERSION should be a positive int, got %r' % (ISOLDE_STATE_VERSION,))
+
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    cas = _ca_atoms(m, 5)
+
+    pr_mgr = sx.get_position_restraint_mgr(m)
+    prs = pr_mgr.add_restraints(cas)
+    prs.targets = cas.coords + 1.0
+    prs.spring_constants = numpy.linspace(100.0, 500.0, len(prs))
+    prs.enableds = True
+
+    dr_mgr = sx.get_distance_restraint_mgr(m)
+    dr = dr_mgr.add_restraint(cas[0], cas[-1])
+    dr.target = 12.5
+    dr.spring_constant = 1234.0
+    dr.enabled = True
+
+    pre = {
+        'n_pos': len(prs),
+        'pos_targets': numpy.array(prs.targets),
+        'pos_k': numpy.array(prs.spring_constants),
+        'pos_en': numpy.array(prs.enableds),
+        'dr_target': dr.target,
+        'dr_k': dr.spring_constant,
+    }
+
+    tmp = tempfile.NamedTemporaryFile(suffix='.cxs', delete=False)
+    tmp.close()
+    try:
+        path = tmp.name.replace('\\', '/')
+        run_cmd(session, 'save "%s" format session' % path, log=False)
+        run_cmd(session, 'close session', log=False)
+        run_cmd(session, 'open "%s"' % path, log=False)
+
+        models = [mm for mm in session.models.list() if type(mm) == AtomicStructure]
+        if len(models) != 1:
+            _fail('expected exactly one structure after restore, got %d' % len(models))
+        m2 = models[0]
+        cas2 = _ca_atoms(m2, 5)
+
+        pr_mgr2 = sx.get_position_restraint_mgr(m2, create=False)
+        if pr_mgr2 is None:
+            _fail('position restraint manager was not restored')
+        prs2 = pr_mgr2.get_restraints(cas2)
+        if len(prs2) != pre['n_pos']:
+            _fail('position restraint count %d != %d' % (len(prs2), pre['n_pos']))
+        if not numpy.allclose(prs2.targets, pre['pos_targets'], atol=1e-3):
+            _fail('position targets did not survive restore')
+        if not numpy.allclose(prs2.spring_constants, pre['pos_k'], atol=1e-3):
+            _fail('position spring constants did not survive restore')
+        if not (numpy.array(prs2.enableds) == pre['pos_en']).all():
+            _fail('position enabled flags did not survive restore')
+        print('PASS: %d position restraints survived save/restore intact' % len(prs2))
+
+        dr_mgr2 = sx.get_distance_restraint_mgr(m2, create=False)
+        if dr_mgr2 is None:
+            _fail('distance restraint manager was not restored')
+        dr2 = dr_mgr2.get_restraint(cas2[0], cas2[-1])
+        if dr2 is None:
+            _fail('distance restraint was not restored')
+        if abs(dr2.target - pre['dr_target']) > 1e-3:
+            _fail('distance target %r != %r' % (dr2.target, pre['dr_target']))
+        if abs(dr2.spring_constant - pre['dr_k']) > 1e-3:
+            _fail('distance spring constant %r != %r' % (dr2.spring_constant, pre['dr_k']))
+        if not dr2.enabled:
+            _fail('distance restraint lost its enabled flag')
+        print('PASS: distance restraint survived save/restore intact')
+        print('PASS: ISOLDE_STATE_VERSION = %d' % ISOLDE_STATE_VERSION)
+    finally:
+        os.unlink(tmp.name)
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)

--- a/isolde/src/tests/test_validation_preflight.py
+++ b/isolde/src/tests/test_validation_preflight.py
@@ -1,0 +1,82 @@
+# @Author: Tristan Croll
+# @Date:   30-Jun-2026
+# @Email:  tcroll@altoslabs.com
+# @Last modified by:   tcroll
+# @Last modified time: 30-Jun-2026
+# @License: Free for non-commercial use (see license.pdf)
+# @Copyright: 2026 Tristan Croll
+'''
+Characterisation test for ISOLDE's read-only validation / preflight QC: the
+hydrogen preflight and the Ramachandran / rotamer outlier reporting. Run inside
+ChimeraX:
+
+    run_chimerax.bat --nogui --exit --script src/tests/test_validation_preflight.py
+
+Asserts the CURRENT reports for the bundled 1pmx fixture against captured
+baselines. Prints PASS/FAIL and exits non-zero on failure.
+'''
+import os
+
+FIXTURE = os.path.join(os.path.dirname(os.path.abspath(__file__)), '1pmx_1.pdb')
+
+# Baselines captured 2026-06 for 1pmx_1.pdb.
+EXPECTED_HYDROGENS = {
+    'status': 'ok', 'hydrogen_count': 513, 'heavy_atom_count': 533,
+    'water_count': 0, 'recommend_addh': False,
+}
+EXPECTED_RAMA = {'n_outliers': 0, 'n_cis': 0, 'n_twisted': 0}
+EXPECTED_ROTA = {'n_rotamers': 57, 'n_non_favored': 10}
+
+
+def _fail(msg):
+    print('FAIL: %s' % msg)
+    raise SystemExit(1)
+
+
+def run(session):
+    from chimerax.core.commands import run as run_cmd
+    from chimerax.isolde import session_extensions as sx
+    m = run_cmd(session, 'open "%s"' % FIXTURE.replace('\\', '/'), log=False)[0]
+    try:
+        # --- hydrogen preflight -------------------------------------------
+        from chimerax.isolde.validation.cmd import isolde_preflight_hydrogens
+        h = isolde_preflight_hydrogens(session, model=m)
+        for key, expect in EXPECTED_HYDROGENS.items():
+            if h.get(key) != expect:
+                _fail('hydrogen preflight %s: expected %r, got %r' % (key, expect, h.get(key)))
+        print('PASS: hydrogen preflight matches baseline (%d H / %d heavy, %s)'
+              % (h['hydrogen_count'], h['heavy_atom_count'], h['status']))
+
+        # --- Ramachandran report ------------------------------------------
+        rama = sx.get_ramachandran_mgr(session)
+        residues = m.residues
+        got_rama = {
+            'n_outliers': len(rama.outliers(residues)),
+            'n_cis': len(rama.cis(residues)),
+            'n_twisted': len(rama.twisted(residues)),
+        }
+        if got_rama != EXPECTED_RAMA:
+            _fail('Ramachandran report changed: %r' % got_rama)
+        print('PASS: Ramachandran report matches baseline %r' % got_rama)
+
+        # --- rotamer report -----------------------------------------------
+        rota = sx.get_rotamer_mgr(session)
+        rotamers = rota.get_rotamers(residues)
+        non_favored, scores = rota.non_favored_rotamers(rotamers)
+        got_rota = {'n_rotamers': len(rotamers), 'n_non_favored': len(non_favored)}
+        if got_rota != EXPECTED_ROTA:
+            _fail('rotamer report changed: %r' % got_rota)
+        print('PASS: rotamer report matches baseline %r' % got_rota)
+    finally:
+        session.models.close([m])
+
+    print('ALL PASS')
+
+
+# ChimeraX --script provides `session` in the module globals.
+try:
+    session  # noqa: F821
+except NameError:
+    session = None
+if session is not None:
+    run(session)


### PR DESCRIPTION
## Summary

Adds a headless test runner and a suite of self-running, **forcefield-independent** tests. Split out from a larger branch; the companion **forcefields** PR carries the parameterisation backends and the tests that exercise them.

### Test runner

`run_tests.bat` discovers every self-running `src/tests/test_*.py`, runs each headlessly via `run_chimerax.bat --nogui --exit --script ...`, and reports pass/fail per file. Success is judged by the `ALL PASS` sentinel in captured output, because a `SystemExit` raised inside a ChimeraX `--script` does not reliably surface as a process exit code. Files without the sentinel (e.g. the interactive `test_simulation.py` harness) are skipped, not failed. The CLAUDE.md **Testing** section documents the convention.

### Forcefield-independent tests

Self-running headless tests that do not depend on the parameterisation backends:

- `test_cmd_surface.py` — command surface / argument specs
- `test_molobject_layer.py` — molobject managers (chiral, proper-dihedral)
- `test_session_roundtrip.py` — session save/restore versioning
- `test_validation_preflight.py` — validation preflight (hydrogens, etc.)
- `gui_mouse_circle.py` — GUI mouse-circle harness

## Notes

- These stand alone against `master` today. The parameterisation-path tests (which import `param_provider`) are in the forcefields PR, since that's where the code they test lives.
- If both PRs are in flight, whichever merges second may need a trivial rebase where they touch the same CLAUDE.md region.
