### PR TITLE
Add Experience level startup setting

### DIFF
--- a/isolde/src/__init__.py
+++ b/isolde/src/__init__.py
@@ -58,6 +58,15 @@ class _MyAPI(BundleAPI):
         if session.ui.is_gui:
             from .toolbar import ToolbarButtonMgr
             session._isolde_tb = ToolbarButtonMgr(session)
+            # Register the ISOLDE settings page. On a cold start the main window
+            # doesn't exist yet (it's built after bundle initialisation), so defer
+            # to the UI 'ready' trigger; if ISOLDE is (re)installed into an already-
+            # running session that trigger has already fired, so register now.
+            if session.ui.main_window is not None:
+                settings.register_settings_options(session)
+            else:
+                session.ui.triggers.add_handler('ready', lambda *args, ses=session:
+                    settings.register_settings_options(ses))
 
     @staticmethod
     def get_class(class_name):

--- a/isolde/src/constants.py
+++ b/isolde/src/constants.py
@@ -150,6 +150,13 @@ class _Defaults:
         'SMOOTHING_ALPHA_MAX':          1.0,
         'SMOOTHING_ALPHA_MIN':          0.01,
 
+        ###
+        # User interface
+        ###
+        # Startup experience level: 0=Default, 1=Advanced, 2=Developer
+        # (matches ExpertModeSelector in ui/ui_base.py)
+        'EXPERIENCE_LEVEL':             0,
+
 
         ###
         # Constants specific to ChimeraX - lengths in Angstroms beyond this point!

--- a/isolde/src/settings.py
+++ b/isolde/src/settings.py
@@ -18,6 +18,8 @@ class _IsoldeBasicSettings(Settings):
         'trajectory_smoothing':             defaults.TRAJECTORY_SMOOTHING,
         'smoothing_alpha':                  defaults.SMOOTHING_ALPHA,
 
+        'experience_level':                 defaults.EXPERIENCE_LEVEL,
+
         'phenix_base_path':                 None,
     }
 
@@ -62,9 +64,21 @@ class _IsoldeAdvancedSettings(Settings):
     }
 
 def register_settings_options(session):
-    from chimerax.ui.options import (
-        ColorOption, BooleanOption, IntOption, FloatOption,
+    from chimerax.ui.options import SymbolicEnumOption
+    # Symbolic names mirror ExpertModeSelector (ui/ui_base.py): the option
+    # displays the labels but stores/returns the integer level (0/1/2).
+    opt = SymbolicEnumOption(
+        'Experience level',
+        basic_settings.experience_level,
+        None,                                   # no extra callback; persistence is automatic
+        values=(0, 1, 2),
+        labels=('Default', 'Advanced', 'Developer'),
+        attr_name='experience_level',
+        settings=basic_settings,
+        balloon='Experience level applied each time ISOLDE starts. Higher '
+                'levels reveal additional advanced and developer controls.',
     )
+    session.ui.main_window.add_settings_option('ISOLDE', opt)
 
 basic_settings = None # set during bundle initialisation
 color_settings = None # set during bundle initialisation

--- a/isolde/src/ui/main_win.py
+++ b/isolde/src/ui/main_win.py
@@ -105,6 +105,15 @@ class IsoldeMainWin(MainToolWindow):
         l1.addWidget(QLabel('Experience level: ', parent=tw))
         from .ui_base import ExpertModeSelector
         elcb = self.expert_mode_combo_box = ExpertModeSelector(tw)
+        # Initialise from the persisted startup default (Favourites > Settings >
+        # ISOLDE). Changing the combo box during a session is transient and does
+        # not write back to the setting.
+        from .. import settings
+        level = getattr(settings.basic_settings, 'experience_level',
+            ExpertModeSelector.DEFAULT)
+        idx = elcb.findData(level)
+        if idx >= 0:
+            elcb.setCurrentIndex(idx)
         l1.addWidget(elcb)
 
         self._isolde_trigger_handlers.append(session.isolde.triggers.add_handler(self.isolde.SIMULATION_STARTED, self._sim_start_cb))


### PR DESCRIPTION
## Summary

Adds a persisted **Experience level** startup setting (Default / Advanced / Developer), independent of any other work.

- `constants.py` — `EXPERIENCE_LEVEL` default (0).
- `settings.py` — `experience_level` basic setting + a `SymbolicEnumOption` registered on the ISOLDE settings page.
- `ui/main_win.py` — the expert-mode combo box initialises from the persisted setting on startup (session changes remain transient).
- `__init__.py` — registers the settings page on the UI `ready` trigger, deferred so it works on both cold start and reinstall-into-a-running-session.

Surfaced via **Favourites → Settings → ISOLDE**. No dependency on the forcefield work; stands alone against `master`.
