### PR TITLE
Add headless test runner (run_tests.bat)

### DIFF
--- a/isolde/CLAUDE.md
+++ b/isolde/CLAUDE.md
@@ -42,7 +42,7 @@ run inside ChimeraX. Two kinds:
   `_fail()` helper that raises `SystemExit`. Run one directly:
 
   ```bat
-  run_chimerax.bat --nogui --exit --script src/tests/test_mmff_parameterisation.py
+  run_chimerax.bat --nogui --exit --script src/tests/test_session_roundtrip.py
   ```
 
   `run_tests.bat` (repo root) discovers every `src/tests/test_*.py`, runs each
@@ -50,7 +50,7 @@ run inside ChimeraX. Two kinds:
   success by the `ALL PASS` sentinel in the output (a `SystemExit` from a
   ChimeraX `--script` does not reliably surface as a process exit code). Files
   with no `ALL PASS` sentinel are skipped, not failed. Examples:
-  `test_mmff_parameterisation.py`, `test_atom_deletion_robustness.py`.
+  `test_session_roundtrip.py`, `test_cmd_surface.py`.
 
 - **Manual/interactive harness:** `test_simulation.py` (`SimTester` class) is
   driven by hand inside a GUI ChimeraX session; it has no headless footer and is

--- a/isolde/CLAUDE.md
+++ b/isolde/CLAUDE.md
@@ -33,7 +33,31 @@ The build preprocesses `pyproject.toml.in` via `prep_toml.py` before invoking th
 
 ## Testing
 
-There is one test file: `isolde/src/tests/test_simulation.py` (`SimTester` class). Tests are run manually inside ChimeraX — there is no pytest runner or CI pipeline. When making changes, load a structure in ChimeraX and exercise the affected feature interactively.
+There is no pytest runner or CI pipeline. Tests live in `isolde/src/tests/` and
+run inside ChimeraX. Two kinds:
+
+- **Self-running headless tests** follow a convention: a
+  `if session is not None: run(session)` footer (ChimeraX injects `session`
+  under `--script`), `run()` prints `ALL PASS` on success, and failures call a
+  `_fail()` helper that raises `SystemExit`. Run one directly:
+
+  ```bat
+  run_chimerax.bat --nogui --exit --script src/tests/test_mmff_parameterisation.py
+  ```
+
+  `run_tests.bat` (repo root) discovers every `src/tests/test_*.py`, runs each
+  self-running test headlessly, and reports pass/fail per file — it judges
+  success by the `ALL PASS` sentinel in the output (a `SystemExit` from a
+  ChimeraX `--script` does not reliably surface as a process exit code). Files
+  with no `ALL PASS` sentinel are skipped, not failed. Examples:
+  `test_mmff_parameterisation.py`, `test_atom_deletion_robustness.py`.
+
+- **Manual/interactive harness:** `test_simulation.py` (`SimTester` class) is
+  driven by hand inside a GUI ChimeraX session; it has no headless footer and is
+  skipped by `run_tests.bat`.
+
+When making changes, also load a structure in ChimeraX and exercise the affected
+feature interactively.
 
 **Do NOT try to test ISOLDE (or Clipper map setup) headless via `--nogui` or
 `--offscreen`.** It does not work and is not worth attempting:

--- a/isolde/run_tests.bat
+++ b/isolde/run_tests.bat
@@ -7,8 +7,8 @@ REM
 REM A "self-contained" test follows the repo convention: it runs itself when
 REM ChimeraX injects `session` (the `if session is not None: run(session)`
 REM footer) and prints "ALL PASS" on success / calls _fail() (which raises
-REM SystemExit) otherwise. See test_mmff_parameterisation.py and
-REM test_atom_deletion_robustness.py for the pattern.
+REM SystemExit) otherwise. See test_session_roundtrip.py and
+REM test_cmd_surface.py for the pattern.
 REM
 REM Files without an "ALL PASS" sentinel are SKIPPED, not failed -- e.g.
 REM test_simulation.py is the interactive SimTester harness (CLAUDE.md: "run

--- a/isolde/run_tests.bat
+++ b/isolde/run_tests.bat
@@ -1,0 +1,77 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+REM ===========================================================================
+REM run_tests.bat -- run every self-contained ISOLDE test under src\tests\
+REM headlessly (via run_chimerax.bat) and report pass/fail per file.
+REM
+REM A "self-contained" test follows the repo convention: it runs itself when
+REM ChimeraX injects `session` (the `if session is not None: run(session)`
+REM footer) and prints "ALL PASS" on success / calls _fail() (which raises
+REM SystemExit) otherwise. See test_mmff_parameterisation.py and
+REM test_atom_deletion_robustness.py for the pattern.
+REM
+REM Files without an "ALL PASS" sentinel are SKIPPED, not failed -- e.g.
+REM test_simulation.py is the interactive SimTester harness (CLAUDE.md: "run
+REM manually inside ChimeraX"), not a headless pass/fail test. Any future test
+REM that adopts the convention is picked up automatically.
+REM
+REM Success is judged by the presence of "ALL PASS" in the captured output, not
+REM by exit code: a SystemExit raised inside a ChimeraX --script does not
+REM reliably surface as a process exit code.
+REM
+REM Usage:  run_tests.bat [release]
+REM   release -> forwarded to run_chimerax.bat to target the stable install
+REM              (omitted -> the daily build), matching run_chimerax.bat's own
+REM              argument convention.
+REM ===========================================================================
+
+set "HERE=%~dp0"
+if "%HERE:~-1%"=="\" set "HERE=%HERE:~0,-1%"
+
+set "RELEASE="
+if /i "%~1"=="release" set "RELEASE=release"
+
+set "TESTDIR=%HERE%\src\tests"
+set "OUT=%TEMP%\isolde_test_out.txt"
+set /a NPASS=0, NFAIL=0, NSKIP=0
+set "FAILED="
+
+REM run from the repo root so the forward-slash --script path resolves the same
+REM way it does when invoked by hand.
+pushd "%HERE%"
+
+echo ===========================================================================
+echo Running ISOLDE tests in %TESTDIR%
+echo ===========================================================================
+
+for %%F in ("%TESTDIR%\test_*.py") do (
+    findstr /c:"ALL PASS" "%%F" >nul 2>&1
+    if errorlevel 1 (
+        echo [SKIP] %%~nxF  ^(no "ALL PASS" sentinel: not a self-running test^)
+        set /a NSKIP+=1
+    ) else (
+        echo.
+        echo --- %%~nxF ---
+        call "%HERE%\run_chimerax.bat" !RELEASE! --nogui --exit --script "src/tests/%%~nxF" > "%OUT%" 2>&1
+        type "%OUT%"
+        findstr /c:"ALL PASS" "%OUT%" >nul 2>&1
+        if errorlevel 1 (
+            echo [FAIL] %%~nxF
+            set /a NFAIL+=1
+            set "FAILED=!FAILED! %%~nxF"
+        ) else (
+            echo [PASS] %%~nxF
+            set /a NPASS+=1
+        )
+    )
+)
+
+echo.
+echo ===========================================================================
+echo Summary: !NPASS! passed, !NFAIL! failed, !NSKIP! skipped
+if not "!FAILED!"=="" echo Failed:!FAILED!
+echo ===========================================================================
+
+popd
+if !NFAIL! gtr 0 exit /b 1
+exit /b 0


### PR DESCRIPTION
## Summary

Adds a headless test runner and documents the testing convention.

- `run_tests.bat` — discovers every self-running `src/tests/test_*.py`, runs each headlessly via `run_chimerax.bat --nogui --exit --script ...`, and reports pass/fail per file. Success is judged by the `ALL PASS` sentinel in captured output, because a `SystemExit` raised inside a ChimeraX `--script` does not reliably surface as a process exit code. Files without the sentinel (e.g. the interactive `test_simulation.py` harness) are skipped, not failed.
- `CLAUDE.md` — the **Testing** section documents the two test kinds and the runner.

Infrastructure only; no dependency on the forcefield work. Stands alone against `master`.
